### PR TITLE
makefile: remove hardcoded deps/luajit paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,54 @@
-LUASRC = $(wildcard src/lua/*.lua)
-LUAOBJ = $(LUASRC:.lua=.o)
-CSRC   = $(wildcard src/c/*.c)
-COBJ   = $(CSRC:.c=.o)
+PWD=$(shell pwd)
 
-LUAJIT_O := deps/luajit/src/libluajit.a
+#luajit related stuff
+LUAJIT_PREFIX?=$(PWD)/deps/.install
+LUAJIT_INSTALL_PATH=$(LUAJIT_PREFIX)/usr/local
+LUAJIT_LIB=$(LUAJIT_INSTALL_PATH)/lib
+
+export LUAJIT=$(LUAJIT_INSTALL_PATH)/bin/luajit-2.1.0-alpha
+export DYNASM_LUA=$(LUAJIT_INSTALL_PATH)/share/luajit-2.1.0-alpha/dynasm/dynasm.lua
+ifneq ("","$(LUAJIT_DYNAMIC_LINK)")
+export CFLAGS_LUAJIT= -L$(LUAJIT_LIB) -lluajit-5.1
+else
+export CFLAGS_LUAJIT= $(LUAJIT_LIB)/libluajit.a
+endif
+export CFLAGS_DEPS = -I $(LUAJIT_INSTALL_PATH)/include/luajit-2.1 -I $(PWD)/deps/include
 
 LUAJIT_CFLAGS := -DLUAJIT_USE_PERFTOOLS -DLUAJIT_USE_GDBJIT -DLUAJIT_NUMMODE=3
 
-all: $(LUAJIT_O)
+all: $(LUAJIT)
 	cd src && $(MAKE)
 
-$(LUAJIT_O): check_luajit deps/luajit/Makefile
+$(LUAJIT): check_luajit
+ifneq ("","$(wildcard deps/luajit/Makefile)")
 	echo 'Building LuaJIT\n'
 	(cd deps/luajit && \
-	 $(MAKE) PREFIX=`pwd`/usr/local \
+	 $(MAKE) PREFIX=$(LUAJIT_PREFIX)/usr/local \
 	         CFLAGS="$(LUAJIT_CFLAGS)" && \
-	 $(MAKE) DESTDIR=`pwd` install)
-	(cd deps/luajit/usr/local/bin; ln -fs luajit-2.1.0-alpha luajit)
+	 $(MAKE) DESTDIR=$(LUAJIT_PREFIX) install)
+	# install the static library
+	install deps/luajit/src/libluajit.a \
+			$(LUAJIT_LIB)/libluajit.a
+	# dynasm is not installed so copy the necessary files
+	install -d $(LUAJIT_INSTALL_PATH)/share/luajit-2.1.0-alpha/dynasm \
+			   $(LUAJIT_INSTALL_PATH)/include/luajit-2.1/dynasm
+	install deps/luajit/dynasm/*.lua \
+	 	$(LUAJIT_INSTALL_PATH)/share/luajit-2.1.0-alpha/dynasm
+	install deps/luajit/dynasm/*.h \
+	 	$(LUAJIT_INSTALL_PATH)/include/luajit-2.1/dynasm
+endif
 
 check_luajit:
-	@if [ ! -f deps/luajit/Makefile ]; then \
+	@if [ ! -f $(LUAJIT) && ! -f deps/luajit/Makefile ]; then \
 	    echo "Can't find deps/luajit/. You might need to: git submodule update --init"; exit 1; \
 	fi
 
 clean:
-	(cd deps/luajit && $(MAKE) clean)
-	(cd src; $(MAKE) clean)
+ifneq ("","$(wildcard deps/luajit/Makefile)")
+	@(cd deps/luajit && $(MAKE) clean)
+	# hardcoded, can be done better
+	@rm -rf deps/.install
+endif
+	@(cd src; $(MAKE) clean)
 
 .SERIAL: all

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,6 @@ LUAOBJ := $(patsubst %.lua,obj/%_lua.o,$(LUASRC))
 COBJ   := $(patsubst %.c,obj/%_c.o,    $(CSRC))
 HOBJ   := $(patsubst %.h,obj/%_h.o,    $(CHDR))
 ASMOBJ := $(patsubst %.dasc,obj/%_dasc.o,   $(ASM))
-JITOBJS:= $(patsubst %,obj/jit_%.o,$(JITSRC))
 EXTRAOBJS := obj/jit_tprof.o obj/jit_vmprof.o obj/strict.o
 RMOBJS := $(patsubst %.src,%,$(RMSRC))
 MDOBJS := $(patsubst %, doc/obj/%.md, $(LUASRC) $(CSRC) $(CHDR)) $(wildcard *.md)
@@ -31,8 +30,6 @@ TESTMODS = $(shell find . -regex '[^\#]*\.lua' -printf '%P ' | \
              xargs grep -l '^function selftest *[[:punct:]]' | \
              sed -e 's_\.lua__' -e 's_/_._g')
 
-PATH := ../deps/luajit/usr/local/bin:$(PATH)
-
 all: snabb
 
 install: snabb
@@ -43,8 +40,7 @@ markdown: $(RMOBJS)
 snabb: $(LUAOBJ) $(HOBJ) $(COBJ) $(ASMOBJ)
 	$(E) "LINK      $@"
 	$(Q) gcc -Wl,--no-as-needed -Wl,-E -Werror -Wall -o $@ $^ \
-	    ../deps/luajit/src/libluajit.a \
-	    -lc -ldl -lm -lrt -lpthread
+	    -lc -ldl -lm -lrt -lpthread $(CFLAGS_LUAJIT)
 	@echo -n "Firmware: "
 	@ln -fs snabb snabbswitch
 	@ls -sh snabb
@@ -77,28 +73,23 @@ $(OBJDIR) testlog:
 
 $(LUAOBJ): obj/%_lua.o: %.lua Makefile | $(OBJDIR)
 	$(E) "LUA       $@"
-	$(Q) luajit -bg -n $(subst /,.,$*) $< $@
+	$(Q) $(LUAJIT) -bg -n $(subst /,.,$*) $< $@
 
 $(COBJ): obj/%_c.o: %.c $(CHDR) Makefile | $(OBJDIR)
 	$(E) "C         $@"
-	$(Q) gcc -Wl,-E -I ../deps/luajit/src -I ../deps/include -I . -c -Wall -Werror -o $@ $<
+	$(Q) gcc -Wl,-E $(CFLAGS_DEPS) -I . -c -Wall -Werror -o $@ $<
 
 $(HOBJ): obj/%_h.o: %.h Makefile | $(OBJDIR)
 	$(E) "H         $@"
 	@(echo -n "module(...,package.seeall); require(\"ffi\").cdef[=============["; \
 	 cat $<; \
 	 echo "]=============]") > $(basename $@).luah
-	$(Q) luajit -bg -n $(subst /,.,$*)_h $(basename $@).luah $@
+	$(Q) $(LUAJIT) -bg -n $(subst /,.,$*)_h $(basename $@).luah $@
 
 $(ASMOBJ): obj/%_dasc.o: %.dasc $(CHDR) Makefile | $(OBJDIR)
 	$(E) "ASM       $@"
-	$(Q) luajit ../deps/luajit/dynasm/dynasm.lua -o $@.gen $<
-	$(Q) gcc -Wl,-E -I ../deps/luajit/src -I . -I ../deps/luajit -c -Wall -Werror -x c -o $@ $@.gen
-
-$(JITOBJS): obj/jit_%.o: ../deps/luajit/src/jit/%.lua $(OBJDIR)
-	$(E) "LUA       $@"
-	$(Q) luajit -bg -n $(patsubst obj/jit_%.o, jit.%, $@) $< $@
-
+	$(Q) $(LUAJIT) $(DYNASM_LUA) -o $@.gen $<
+	$(Q) gcc -Wl,-E $(CFLAGS_DEPS) -I . -c -Wall -Werror -x c -o $@ $@.gen
 
 $(RMOBJS): %: %.src
 	$(E) "MARKDOWN  $@"
@@ -107,15 +98,15 @@ $(RMOBJS): %: %.src
 # extra/ third party bits and pieces
 obj/strict.o: extra/strict.lua | $(OBJDIR)
 	$(E) "LUA       $@"
-	$(Q) luajit -bg $< $@
+	$(Q) $(LUAJIT) -bg $< $@
 
 obj/jit_tprof.o: extra/tprof.lua | $(OBJDIR)
 	$(E) "LUA       $@"
-	$(Q) luajit -bg -n jit.tprof $< $@
+	$(Q) $(LUAJIT) -bg -n jit.tprof $< $@
 
 obj/jit_vmprof.o: extra/vmprof.c | $(OBJDIR)
 	$(E) "C         $@"
-	$(Q) gcc -Wl,-E -O2 -I ../deps/luajit/src -c -Wall -Werror -o $@ $<
+	$(Q) gcc -Wl,-E -O2 $(CFLAGS_DEPS) -c -Wall -Werror -o $@ $<
 
 
 doc/obj/%.lua.md : %.lua Makefile

--- a/src/jit/bc.lua
+++ b/src/jit/bc.lua
@@ -1,1 +1,0 @@
-../../deps/luajit/src/jit/bc.lua

--- a/src/jit/bcsave.lua
+++ b/src/jit/bcsave.lua
@@ -1,1 +1,0 @@
-../../deps/luajit/src/jit/bcsave.lua

--- a/src/jit/dis_x64.lua
+++ b/src/jit/dis_x64.lua
@@ -1,1 +1,0 @@
-../../deps/luajit/src/jit/dis_x64.lua

--- a/src/jit/dis_x86.lua
+++ b/src/jit/dis_x86.lua
@@ -1,1 +1,0 @@
-../../deps/luajit/src/jit/dis_x86.lua

--- a/src/jit/dump.lua
+++ b/src/jit/dump.lua
@@ -1,1 +1,0 @@
-../../deps/luajit/src/jit/dump.lua

--- a/src/jit/p.lua
+++ b/src/jit/p.lua
@@ -1,1 +1,0 @@
-../../deps/luajit/src/jit/p.lua

--- a/src/jit/v.lua
+++ b/src/jit/v.lua
@@ -1,1 +1,0 @@
-../../deps/luajit/src/jit/v.lua

--- a/src/jit/vmdef.lua
+++ b/src/jit/vmdef.lua
@@ -1,1 +1,0 @@
-../../deps/luajit/src/jit/vmdef.lua

--- a/src/jit/zone.lua
+++ b/src/jit/zone.lua
@@ -1,1 +1,0 @@
-../../deps/luajit/src/jit/zone.lua


### PR DESCRIPTION
In-tree luajit installation is moved to deps/.install
The dynasm *lua and *h files are copied there too.

All references to ../deps in src/Makefile are replaced with env variables.
Those are exported in the root Makefile.

To link to the dynamic luajit library compile with:
 LUAJIT_DYNAMIC_LINK=1 make

To compile with externally install luajit library:
 LUAJIT_PREFIX=/path/to/luajit/installation make

Signed-off-by: Nikolay Nikolaev <n.nikolaev@virtualopensystems.com>