### PR TITLE
Trace-NG: Trace app networks to PCAP-NG files [SKETCH]

### DIFF
--- a/src/apps/ipv6/ipv6.lua
+++ b/src/apps/ipv6/ipv6.lua
@@ -190,6 +190,7 @@ function selftest ()
    config.link(c, "source.output -> ipv6.eth0")
    config.link(c, "ipv6.eth0 -> sink.input")
    app.configure(c)
+   app.trace("apps/ipv6/trace.pcapng")
    app.main({duration = 0.25}) -- should be long enough...
    -- Check results
    if io.open("apps/ipv6/selftest.cap.output"):read('*a') ~=

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -253,6 +253,7 @@ function breathe ()
       for i = 1, #link_array do
          local link = link_array[i]
          if firstloop or link.has_new_data then
+            trace_link(link)
             link.has_new_data = false
             local receiver = app_array[link.receiving_app]
             if receiver.push and not receiver.dead then
@@ -266,6 +267,26 @@ function breathe ()
       firstloop = false
    until not progress  -- Stop after no link had new data
    breaths = breaths + 1
+end
+
+tracefile = false
+
+-- Enable tracing to FILENAME for all links whose name matches PATTERN.
+-- If NPACKETS is given then stop recording after this many packets.
+function trace (filename, pattern,  npackets)
+   tracefile = pcapng.open_trace_for_write (filename)
+   for name, l in pairs(link_table) do
+      if (<link name matches pattern>) then
+         pcapng.write_interface_description(trace, name, l)
+         -- Enable tracing future packets
+         l.trace = l.write
+   end
+end
+
+function trace_link (l)
+   while link.traceable(l) do
+      pcapng.write_packet(tracefile, l.tracenext(), monotonic_now)
+   end
 end
 
 function report (options)

--- a/src/core/link.h
+++ b/src/core/link.h
@@ -5,10 +5,11 @@ enum { LINK_RING_SIZE    = 8192,
 struct link {
   // this is a circular ring buffer, as described at:
   //   http://en.wikipedia.org/wiki/Circular_buffer
-  // Two cursors:
+  // Three cursors:
   //   read:  the next element to be read
   //   write: the next element to be written
-  int read, write;
+  //   trace: the next element to be traced (-1 means tracing is disabled)
+  int read, write, trace;
   // Index (into the Lua app.active_apps array) of the app that
   // receives from this link.
   int receiving_app;

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -15,7 +15,7 @@ local size = C.LINK_RING_SIZE         -- NB: Huge slow-down if this is not local
 max        = C.LINK_MAX_PACKETS
 
 function new (receiving_app)
-   return ffi.new("struct link", {receiving_app = receiving_app})
+   return ffi.new("struct link", {receiving_app = receiving_app, trace = -1})
 end
 
 function receive (r)
@@ -49,6 +49,15 @@ end
 -- Return true if the ring is full.
 function full (r)
    return band(r.write + 1, size - 1) == r.read
+end
+
+-- Return the next packet to trace, or nil if none is ready.
+function tracenext (r)
+   if r.trace ~= -1 and r.trace ~= r.write then
+      local p = r.packets[r.trace]
+      r.trace = band(r.trace + 1, size - 1)
+      return p
+   end
 end
 
 -- Return the number of packets that are ready for read.

--- a/src/lib/pcap/pcapng.lua
+++ b/src/lib/pcap/pcapng.lua
@@ -1,0 +1,51 @@
+// See:
+//   http://www.winpcap.org/ntar/draft/PCAP-DumpFileFormat.html
+//   https://github.com/the-tcpdump-group/libpcap/blob/master/sf-pcap-ng.c
+module(...,package.seeall)
+
+local ffi = require("ffi")
+
+ffi.cdef[[
+struct pcapng_block_header {
+   uint32_t block_type;
+   uint32_t total_length;
+};
+
+struct pcapng_block_trailer {
+   uint32_t total_length;
+};
+
+struct pcapng_option_header {
+   uint16_t option_code;
+   uint16_t option_length;
+};
+
+struct pcapng_interface_description {
+   uint16_t linktype;
+   uint16_t reserved;
+   uint32_t snaplen;
+   // ... options, trailer ...
+};
+
+struct pcapng_enhanced_packet_fields {
+   uint32_t interface_id;
+   uint32_t timestamp_high;
+   uint32_t timestamp_low;
+   uint32_t caplen;
+   uint32_t len;
+   // ... packet data, options, trailer ...
+};
+]]
+
+function open_trace_for_write (filename)
+end
+
+function write_interface_description (trace, name, l)
+end
+
+function write_packet (trace, p, timestamp)
+end
+
+function close_trace (trace)
+end
+


### PR DESCRIPTION
This is a design sketch for efficiently tracing packets passing through the app network to one coherent file that can be inspected in wireshark.

Once the basic implementation is working we should extend it to be suitable for use in production on live snabbswitches:
- Automatically throttle or disable tracing when CPU is overloaded.
- Ensure that we never block on I/O. Have to use some suitable Linux mechanism. Maybe mmap()ed file with mlock(), async I/O, or pthread to call write() would work.

Based on the snabb-devel post: https://groups.google.com/forum/#!topic/snabb-devel/jJgPJkNCP6U