### PR TITLE
snabb-nfv tests: run the iperf client parallelized.

### DIFF
--- a/src/lib/nfv/selftest.sh
+++ b/src/lib/nfv/selftest.sh
@@ -126,8 +126,8 @@ function test_checksum {
 function test_iperf {
     run_telnet $2 "nohup iperf -d -s -V &" >/dev/null
     sleep 2
-    run_telnet $1 "iperf -c $3 -V" 20 \
-        | grep "s/sec"
+    run_telnet $1 "iperf -c $3 -P8 -V" 20 \
+        | grep "SUM.*s/sec"
     assert IPERF $?
 }
 


### PR DESCRIPTION
  * This is needed to achieve ~10 Gbits/sec after jumboframes are
    enabled. Tested on chur.

  * It should be noted that raising the number of cores on the VMs
    (-smp X) can also help to achieve a higher bandwidth.


On chur, when running the script lib/nfv/selftest.sh before and after this patch, I get this diff:

```diff
--- before	2014-11-05 20:13:03.058235012 +0100
+++ after	2014-11-05 20:18:23.187862302 +0100
@@ -1,3 +1,4 @@
 lib/nfv/selftest.sh: line 26: /etc/bench_conf.sh: No such file or directory
 Configuration file /etc/bench_conf.sh not found.
 No /etc/bench_conf.sh found
@@ -55,11 +56,11 @@
 TESTING same_vlan.ports
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
 PING succeded.
-[  3]  0.0-10.0 sec  3.96 GBytes  3.40 Gbits/sec
+[SUM]  0.0-10.0 sec  3.81 GBytes  3.27 Gbits/sec
 IPERF succeded.
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
 JUMBOPING succeded.
-[  3]  0.0-10.0 sec  6.98 GBytes  6.00 Gbits/sec
+[SUM]  0.0-10.0 sec  11.2 GBytes  9.61 Gbits/sec
 IPERF succeded.
 Waiting QEMU processes to terminate...
 Finished.
@@ -124,11 +125,11 @@
 ND succeded.
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
 PING succeded.
-[  3]  0.0-10.0 sec  3.90 GBytes  3.35 Gbits/sec
+[SUM]  0.0-10.0 sec  4.03 GBytes  3.45 Gbits/sec
 IPERF succeded.
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
 JUMBOPING succeded.
-[  3]  0.0-10.0 sec  5.82 GBytes  5.00 Gbits/sec
+[SUM]  0.0-10.0 sec  11.1 GBytes  9.54 Gbits/sec
 IPERF succeded.
 Waiting QEMU processes to terminate...
 Finished.
```