### PR TITLE
Add support for jit.dump and jit.profile to a file.

### DIFF
--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -25,18 +25,19 @@ ffi.cdef[[
 local usage = [[
 Usage: snabb [options] <module> [args...]
 Available options are:
--P pathspec  Set library load path (Lua 'package.path').
--e chunk     Execute string 'chunk'.
--l name      Require library 'name'.
--t name      Test module 'name' with selftest().
--R           Start interactive Snabb REPL.
--dm          Enable developer mode. Enables debug prints and asserts.
--d           Debug unhandled errors with the Lua interactive debugger.
--S           Print enhanced stack traces with more debug information.
--jdump file  Trace JIT decisions to 'file'. (Requires LuaJIT jit.* library.)
--jv file     Prints verbose information about the the JIT compiler to 'file'.
--jp          Profile with the LuaJIT statistical profiler.
--jp=args[,.output]
+-P pathspec           Set library load path (Lua 'package.path').
+-e chunk              Execute string 'chunk'.
+-l name               Require library 'name'.
+-t name               Test module 'name' with selftest().
+-R                    Start interactive Snabb REPL.
+-dm                   Enable developer mode. Enables debug prints and asserts.
+-d                    Debug unhandled errors with the Lua interactive debugger.
+-S                    Print enhanced stack traces with more debug information.
+-jv file              Prints verbose information about the the JIT compiler to 'file'.
+-jp                   Profile with the LuaJIT statistical profiler.
+-jp=args[,.output]    Profile to 'file'. 
+-jdump                Trace JIT decisions (Requires LuaJIT jit.* library).
+-jdump=args[,.output] Trace JIT decisions to 'file'.
 ]]
 
 _G.developer_debug = false
@@ -86,10 +87,11 @@ function main ()
          require("jit.p").start(pargs, poutput)
          profiling = true
          i = i + 1
-      elseif args[i] == '-jdump' and i < #args then
-         local jit_dump = require "jit.dump"
-         jit_dump.start("", args[i+1])
-         i = i + 2
+      elseif (args[i]):match("-jdump") then
+         local args, output = (args[i]):gmatch("-jdump=([^,]*),?(.*)")()
+         if output == '' then output = nil end
+         require("jit.dump").start(args, output)
+         i = i + 1
       elseif args[i] == '-jv' and i < #args then
          local jit_verbose = require 'jit.v'
          jit_verbose.start(args[i+1])

--- a/src/designs/neutron/snabbnfv-bench
+++ b/src/designs/neutron/snabbnfv-bench
@@ -32,10 +32,16 @@ function run (pciaddr, confpath, sockpath, npackets)
          bytes = app.app_table[virtio].input.rx.stats.rxbytes
          start = C.get_monotonic_time()
          if os.getenv("NFV_PROF") then
-            require("jit.p").start(os.getenv("NFV_PROF"))
+            require("jit.p").start(os.getenv("NFV_PROF"), os.getenv("NFV_PROF_FILE"))
             main.profiling = true
          else
             print("No LuaJIT profiling enabled ($NFV_PROF unset).")
+         end
+         if os.getenv("NFV_DUMP") then
+            require("jit.dump").start(os.getenv("NFV_DUMP"), os.getenv("NFV_DUMP_FILE"))
+            main.dumping = true
+         else
+            print("No LuaJIT dump enabled ($NFV_DUMP unset).")
          end
       end
       return app.app_table[virtio].input.rx.stats.rxpackets - packets >= npackets


### PR DESCRIPTION
src/designs/neutron/snabbnfv-bench has support for gettting a profile session via NFV_PROF env variable. This patch adds support for writing the result of the profile to a file (NFV_PROF_FILE) and implements support for dumps (NFV_DUMP, NFV_DUMP_FILE).