### PR TITLE
[neutron-sync] Use constant disk space for neutron-sync-master/neutron-sync-agent

### DIFF
--- a/src/designs/neutron/neutron-sync-agent
+++ b/src/designs/neutron/neutron-sync-agent
@@ -37,13 +37,15 @@ initial=true
 # Loop pulling/cloning the repo.
 while true; do
     if [ ! -d $NEUTRON_DIR ]; then
-    git clone --depth 1 git://$SYNC_HOST/$SYNC_PATH $NEUTRON_DIR
+    git clone git://$SYNC_HOST/$SYNC_PATH $NEUTRON_DIR
     fi
     cd $NEUTRON_DIR
     git fetch
     git diff --quiet origin/master
     if [ $? != 0 -o $initial = true ]; then
         git pull --rebase origin master
+        git reflog expire --expire-unreachable=0 --all
+        git prune --expire 0
         echo "Generating new configuration"
         sudo $NEUTRON2SNABB $NEUTRON_DIR $TMP_DIR
         # Only (atomically) replace configurations that have changed.

--- a/src/designs/neutron/neutron-sync-master
+++ b/src/designs/neutron/neutron-sync-master
@@ -39,7 +39,14 @@ function run()
             -P ${DB_PORT} -T ${DB_DUMP_PATH} ${DB_NEUTRON} ${DB_NEUTRON_TABLES}
         rm -f *.sql
         git add *.txt >/dev/null
-        git commit -m "Configuration update" >/dev/null
+        if [ $initial = true ]; then
+            git commit -m "Configuration update" >/dev/null
+            initial=false
+        else
+            git commit --amend -m "Configuration update" >/dev/null
+            git reflog expire --expire-unreachable=0 --all
+            git prune --expire 0
+        fi
         sleep "$SYNC_INTERVAL"
         #check that the daemon is still running
         GITPID=$(cat /tmp/neutron-sync-master.pid)
@@ -62,5 +69,6 @@ echo "DBG: \$DB_DUMP_PATH = $DB_DUMP_PATH"
 [ -d "$DB_DUMP_PATH/.git" ] || git init "$DB_DUMP_PATH" || error 'MAIN: error initializing repo'
 
 #sudo chmod 777 "$DB_DUMP_PATH"
+initial=true
 run "$DB_DUMP_PATH"
 


### PR DESCRIPTION
Uses `git commit --amend`, `git reflog expire` and `git prune` to operate sync master and agent with constant disk space usage.

Based on this test: https://gist.github.com/eugeneia/babaa842e6e34fcf5fc1

Note: I didn't try to prune periodically (instead of after each commit/pull) because I assume that pruning a single-commit-repo will always be a cheap operation. 