### PR TITLE
IPC method using file-backed shared memory

### DIFF
--- a/src/lib/ipc/shmem/counter.lua
+++ b/src/lib/ipc/shmem/counter.lua
@@ -1,0 +1,50 @@
+-- The counter subclass of lib.ipc.shmem.shmem manages a shared memory
+-- mapping dedicated to counters.  It defines the name space "Counter"
+-- and contains exclusively unsigned 64-bit objects.  Because all
+-- objects are of the same type, the index file for this name space
+-- contains only the names of the objects.  The type (uint64_t) and
+-- length (8 bytes) is implied.
+--
+-- The procedural interface can be used to avoid method-call overhead.
+-- The set of counters may also be accessed by treating the entire
+-- segment as an array of doubles
+--
+--  local array = ffi.cast("uint64_t *", counter:base())
+--  array[i] = ...
+--
+module(..., package.seeall)
+
+local ffi = require("ffi")
+local C = ffi.C
+local shmem = require("lib.ipc.shmem.shmem")
+
+local counter = subClass(shmem)
+counter._name = "Counter shared memory"
+counter._namespace = "Counter:1"
+-- Suppress the length field in the index file
+counter._fs = ''
+
+local uint64_t = ffi.typeof("uint64_t")
+function counter:register (name, value)
+   return counter:superClass().register(self, name, uint64_t, value)
+end
+
+function counter:add (name, value)
+   add(self:ptr(name), value)
+end
+
+-- Procedural interface
+
+function add (counter, value)
+   counter[0] = counter[0] + value
+end
+
+function get (counter)
+   return counter[0]
+end
+
+function set (counter, value)
+   counter[0] = value
+end
+
+return counter

--- a/src/lib/ipc/shmem/mib.lua
+++ b/src/lib/ipc/shmem/mib.lua
@@ -1,0 +1,149 @@
+-- Subclass of ipc.shmem.shmem that handles data types from the SMIv2
+-- specification.
+--
+-- It defines the name space "MIB", which uses the default index
+-- format.  By definition, the object names must be literal OIDs or
+-- textual object identifiers that can be directly translated into
+-- OIDs through a MIB (e.g. ".1.3.6.1.2.1.1.3" or "sysUpTime").  Names
+-- that do not comply to this requirement can be used upon agreement
+-- between the producer and consumer of an instance of this class.
+--
+-- The intended consumer of this data is an SNMP agent or sub-agent
+-- that runs on the same host and is able to serve the sub-trees that
+-- cover all of the OIDs in the index to regular SNMP clients
+-- (e.g. monitoring stations).  It is recommended that the OIDs do
+-- *not* include any indices for conceptual rows of the relevant MIB
+-- (this includes the ".0" instance id of scalar objects).  The SNMP
+-- (sub-)agent should know the structure of the MIB and construct all
+-- indices itself.  This may require the inclusion of non-MIB objects
+-- in the data file for MIBs whose specification does not include the
+-- index objects in the rows itself (which represents an example of
+-- the situation where the consumer and producer will have to agree
+-- upon a naming convention beyond the regular name space).
+--
+-- Usage of the numerical data types is straight forward.  Octet
+-- strings are encoded as a sequence of a 2-byte length field (uint16)
+-- followed by the indicated number of bytes.  The maximum length is
+-- fixed upon creation of the container of the string.  The size of
+-- the object (as registered in the index file) is 1+n, where n is the
+-- maximum length of the octet string.
+--
+module(..., package.seeall)
+
+local ffi = require("ffi")
+local shmem = require("lib.ipc.shmem.shmem")
+
+local mib = subClass(shmem)
+mib._name = "MIB shared memory"
+mib._namespace = "MIB:1"
+
+local int32_t = ffi.typeof("int32_t")
+local uint32_t = ffi.typeof("uint32_t")
+local uint64_t = ffi.typeof("uint64_t")
+local octetstr_types = {}
+local function octetstr_t (size)
+   assert(size <= 65535)
+   if octetstr_types[size] then
+      return octetstr_types[size]
+   else
+      local type = ffi.typeof(
+	 [[
+	       struct { uint16_t length; 
+			uint8_t data[$]; 
+		     } __attribute__((packed))
+	 ]], size)
+      octetstr_types[size] = type
+      return type
+   end
+end
+
+-- Types according to the SMIv2, RFC 2578 (Section 7.1). The default
+-- 'OctetStr' supports octet strings up to 255 bytes.
+local types = { Integer32 = int32_t,
+		Unsigned32 = uint32_t,
+		OctetStr = octetstr_t(255),
+		Counter32 = uint32_t,
+		Counter64 = uint64_t,
+		Gauge32 = uint32_t,
+		TimeTicks = uint32_t,
+	     }
+
+-- The 'type' argument of the constructor must either be a string that
+-- identifies one of the supported types
+--
+--  Integer32
+--  Unsigned32
+--  OctetStr
+--  Counter32
+--  Counter64
+--  Gauge32
+--  TimeTicks
+--
+-- or a table of the form { type = 'OctetStr', length = <length> },
+-- where <length> is an integer in the range 0..65535.  The simple
+-- type 'OctetStr' is equivalent to the extended OctetStr type with
+-- length=255.  An OctetStr can hold any sequence of bytes up to a
+-- length of <length>.  The sequence is passed as a Lua string to the
+-- register() and set() methods and received as such from the get()
+-- method.
+--
+-- The "type" field of the table may also contain any of the other
+-- valid types.  In this case, all other fields in the table are
+-- ignored and the method behaves as if the type had been passed as a
+-- string.
+function mib:register (name, type, value)
+   assert(name and type)
+   local ctype
+   local octetstr_p = false
+   if _G.type(type) == 'table' then
+      if type.type == 'OctetStr' then
+	 assert(type.length and type.length <= 65535)
+	 ctype = octetstr_t(type.length)
+	 octetstr_p = true
+      else
+	 -- Accept all other legal types
+	 type = type.type
+      end
+   elseif type == 'OctetStr' then
+      octetstr_p = true
+   end
+   ctype = ctype or types[type]
+   if ctype == nil then
+      error("illegal SMIv2 type "..type)
+   end
+   local ptr = mib:superClass().register(self, name, ctype)
+   self._objs[name].octetstr_p = octetstr_p
+   self:set(name, value)
+   return ptr
+end
+
+-- Same as the base method, except for objects of type OctetStr.  In
+-- this case, the value must be a Lua string, which will be stored in
+-- the "data" portion of the underlying octet string data type.  The
+-- string is truncated to the maximum size of the object.
+function mib:set (name, value)
+   local obj = self._objs[name]
+   if obj and obj.octetstr_p and value ~= nil then
+      local length = math.min(string.len(value), obj.length - 2)
+      local octet = mib:superClass().get(self, name)
+      octet.length = length
+      ffi.copy(octet.data, value, length)
+   else
+      mib:superClass().set(self, name, value)
+   end
+end
+
+-- Same as the base method, except for objects of type OctetStr.  In
+-- this case, the returned value is the "data" portion of the
+-- underlying octet string, converted to a Lua string.
+function mib:get (name)
+   local octet = mib:superClass().get(self, name)
+   local obj = self._objs[name]
+   if obj.octetstr_p then
+      return ffi.string(octet.data, octet.length)
+   else
+      return octet
+   end
+end
+
+return mib

--- a/src/lib/ipc/shmem/shmem.c
+++ b/src/lib/ipc/shmem/shmem.c
@@ -1,0 +1,38 @@
+#include <sys/mman.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <stdbool.h>
+
+bool shmem_unmap(void *mem, size_t size) {
+  if (munmap(mem, size) == -1) {
+    perror("munmap");
+    return(false);
+  }
+  return(true);
+}
+
+// Note: the io.* file handle passed to us is converted to a Unix
+// filehandle (FILE *) by LuaJIT
+char *shmem_grow(void *fh, void *old_mem, size_t old_size, size_t new_size) {
+  int fd;
+  void *mem;
+
+  if (old_mem != NULL) {
+    if (shmem_unmap(old_mem, old_size) == false) {
+      return(NULL);
+    }
+  }
+  fd = fileno(fh);
+  if (ftruncate(fd, new_size) == -1) {
+    perror("ftruncate");
+    return(NULL);
+  }
+  if ((mem = mmap(old_mem, new_size, PROT_READ|PROT_WRITE, MAP_SHARED,
+		  fd, 0)) == MAP_FAILED) {
+    perror("mmap");
+    return(NULL);
+  }
+  return((char *)mem);
+}
+

--- a/src/lib/ipc/shmem/shmem.h
+++ b/src/lib/ipc/shmem/shmem.h
@@ -1,0 +1,2 @@
+char *shmem_grow(void *, void *, size_t, size_t);
+bool shmem_unmap(void *, size_t);

--- a/src/lib/ipc/shmem/shmem.lua
+++ b/src/lib/ipc/shmem/shmem.lua
@@ -1,0 +1,267 @@
+-- The shmem base class provides a simple IPC mechanism to exchange
+-- arbitrary cdata objects with other processes through a file-backed
+-- shared memeory region.
+--
+-- A new empty region is created by calling the constructor with a
+-- filename and optional directory, where the file should be created.
+--
+--  local shmem = require("lib.ipc.shmem.shmem")
+--  local foo = shmem:new({ filename = "foo", directory = "/tmp" })
+--
+-- If omitted, the directory defaults to "/tmp/snabb-shmem".  The
+-- constructor creates an empty file called the "data file" with the
+-- given name and maps it into the processe's virtual memory.  In
+-- addition, it creates an "index file" by appending the suffix
+-- ".index" to the data file name.  The first line of the index file
+-- contains a string that identifies the name space to which the
+-- memory region belongs, followed by a colon, followed by an integer
+-- version number.  The name space indicates how the rest of the index
+-- file needs to be interpreted.  A name space is tied to the subclass
+-- that implements it (but a subclass may inherit the name space of
+-- its ancestor class).  The version number allows for changes of the
+-- index format within the name space.
+--
+-- The base class provides the name space "default", i.e. the header
+-- line of the index file for version 1 contains the string "default:1".
+--
+-- The default name space contains a single line in the index file for
+-- every object stored in the memory region.  The order of the
+-- descriptions must be the same as that of the objects.  A
+-- description consists of an arbitrary name, followd by a colon,
+-- followed by the length of the corresponding object in bytes.  For
+-- example, the index file
+--
+--   default:1
+--   foo:4
+--   bar:7
+--
+-- Describes a memory region of length 11, which contains an object
+-- named 'foo' that consists of 4 bytes starting at offset 0 and an
+-- object named 'bar' consisting of 7 bytes starting at offset 4.  The
+-- type of the object is implied by its name and is not part of the
+-- description in the index. Each name must be unique.
+--
+-- An object is added to the region by calling the method register(),
+-- which takes a string, a ctype object and an optional value as
+-- arguments.  The ctype must refer to a complete type such that the
+-- size of the object is fixed when it is added to the index.  The
+-- following example adds an unsigned 32-bit number called "counter"
+-- and a struct named "bar":
+--
+--  local counter_t = ffi.typeof("uint32_t")
+--  local bar_t = ffi.typeof("struct { uint8_t x; char string[10]; }")
+--  foo:register("counter", counter_t, 42)
+--  foo:register("bar", bar_t)
+--
+-- The index file now contains
+--
+--  default:1
+--  counter:4
+--  bar:11
+--
+-- The contents of the objects can be changed by the set() method
+--
+--  foo:set("counter", 1)
+--  foo:set("bar", bar_t({ x = 1, string = 'bar' }))
+--
+-- The provided value must be of the correct type or must be
+-- convertible to it.  The assignment is performed by de-referencing
+-- the address of the object as a pointer, equivalent to (where
+-- "ctype" is the ctype object passed to the register() method)
+--
+--  ffi.cast(ffi.typeof("$*", ctype), address)[0] = value
+--
+-- The get() method returns just a reference to the object
+--
+--  ffi.cast(ffi.typeof("$*", ctype), address)[0]
+--
+-- For certain types, this will result in a Lua object, complex data
+-- types are represented as references
+--
+--  print(type(foo:get("counter")))  --> number
+--  print(type(foo:get("bar")))      --> cdata<struct 403 &>: 0x7f2ce4efb004
+--
+-- Be aware that assignments to the latter will change the underlying
+-- object, while simple objects obtained from get() are distinct from
+-- the underlying object.
+--
+-- To manipulate any type of object "in place", one first obtains a
+-- pointer to the object by calling the ptr() method and de-references
+-- that pointer
+--
+--  local c = test:ptr("counter")
+--  c[0] = 42
+--  print(test:get("counter")) --> 42
+--
+module(..., package.seeall)
+
+local ffi = require("ffi")
+local C = ffi.C
+
+require("lib.ipc.shmem.shmem_h")
+
+local shmem = subClass(nil)
+shmem._name = "shared memory base class"
+
+---- Class variables
+-- Should be overridden by derived classes
+shmem._namespace = "default:1"
+-- The character(s) used as field separator in the index file.  Can be
+-- overriden by derived classes.  Object names that contain the field
+-- separator are considered illegal by the register() method.  A value
+-- of '' suppresses the length field in the index file.
+shmem._fs = ':'
+
+local defaults =  {
+   directory = '/tmp/snabb-shmem',
+}
+
+---- Class methods
+
+-- Options:
+-- { filename = <filename>,
+--   [ directory = <directory>, ] Default: /tmp/snabb-shmem
+-- }
+--
+function shmem:new (options)
+   assert(options and options.filename) 
+   local o = shmem:superClass().new(self)
+   local dir = options.directory or defaults.directory
+   if dir ~= '' then
+      o._data_filename = table.concat({ dir, options.filename}, '/')
+   else
+      o._data_filename = options.filename
+   end
+   o._data_fh = assert(io.open(o._data_filename, 'w+'))
+   o._index_filename = o._data_filename..".index"
+   o._index_fh = assert(io.open(o._index_filename, 'w+'))
+   assert(o._index_fh:write(o._namespace, '\n'))
+   assert(o._index_fh:flush())
+   o._size = 0
+   o._base = nil
+   o._objs = {}
+   return o
+end
+
+---- Instance methods
+
+-- Append an object with the given name and ctype to the shared memory
+-- region and add its description to the index file.  If a value is
+-- supplied, the object is initialized with it via the set() method.
+--
+-- The method returns a pointer to the object via the ptr() method.
+-- The method aborts if the memeory region can't be grown via
+-- munmap()/mmap() or if the updating of the index file fails.
+function shmem:register (name, ctype, value)
+   assert(name and ctype)
+   assert(not self._objs[name], "object already exists: "..name)
+   assert(self._fs == '' or not string.find(name, self._fs),
+	  "illegal object name: "..name)
+   local length = ffi.sizeof(ctype)
+   -- Store the location of the object as an offset relative to the
+   -- base, because the base may change across calls to shmem_grow()
+   self._objs[name] = { offset    = self._size,
+			ctype     = ctype,
+			ctype_ptr = ffi.typeof("$*", ctype),
+			length    = length }
+   local new_size = self._size + length
+   self._base = C.shmem_grow(self._data_fh, self._base,
+			    self._size, new_size)
+   assert(self._base ~= nil, "mmap failed")
+   self._size = new_size
+   self:set(name, value)
+   local line = name
+   if self._fs and self._fs ~= '' then
+      line = line..self._fs..length
+   end
+   assert(self._index_fh:write(line, '\n'))
+   assert(self._index_fh:flush())
+   return self:ptr(name)
+end
+
+-- Return the base address of the mapped memory region.  It is unsafe
+-- to use this value across calls to the register() method, because
+-- the region may be moved during the munmap()/mmap() procedure.
+function shmem:base ()
+   return self._base
+end
+
+local function get_obj(self, name)
+   local obj = self._objs[name]
+   if obj == nil then
+      error("unkown object: "..name)
+   end
+   return obj
+end
+
+-- Set a named object to the given value.  
+function shmem:set (name, value)
+   if value ~= nil then
+      local obj = get_obj(self, name)
+      ffi.cast(obj.ctype_ptr, self._base + obj.offset)[0] = value
+   end
+end
+
+-- Return the value of a named object by de-referencing the pointer to
+-- its location in memory.  This will trigger conversions to Lua types
+-- where applicable.  For more complex cdata objects, the returned
+-- value will be a reference to the object.
+function shmem:get (name)
+   local obj = get_obj(self, name)
+   return ffi.cast(obj.ctype_ptr, self._base + obj.offset)[0]
+end
+
+-- Return the address of the named object in memory as a pointer to
+-- the object's ctype.  The object itself can be accessed by
+-- de-referencing this pointer.
+function shmem:ptr (name)
+   local obj = get_obj(self, name)
+   return ffi.cast(obj.ctype_ptr, self._base + obj.offset)
+end
+
+-- Return the ctype of the named object as provided by the "ctype"
+-- argument to the register() method when the object was created.
+function shmem:ctype (name)
+   local obj = get_obj(self, name)
+   return obj.ctype
+end
+
+function selftest ()
+   local test = shmem:new({ filename = 'selftest', directory = '' })
+   local bar_t = ffi.typeof("struct { uint8_t x; char string[10]; }")
+   test:register("counter", ffi.typeof("uint32_t"))
+   test:register('bar', bar_t)
+   test:set('bar', bar_t({ x = 1, string = 'foo'}))
+   local bar = test:get('bar')
+   local bar_ptr = test:ptr('bar')
+   assert(bar.x == 1)
+   assert(ffi.string(bar.string) == 'foo')
+   assert(bar_ptr[0].x == 1)
+   assert(ffi.string(bar_ptr[0].string) == 'foo')
+
+   local ifile = assert(io.open("selftest.index", "r"))
+   local cfile = assert(io.open("selftest", "r"))
+   local function fields(fh)
+      local next, field = ifile:read('*l'):split(':')
+      return next(field), next(field)
+   end
+
+   -- Check header
+   local namespace, version = fields(ifile)
+   assert(namespace == 'default')
+   assert(tonumber(version) == 1)
+
+   -- Check names
+   local name, len = fields(ifile)
+   assert(name == 'counter' and tonumber(len) == 4)
+   name, len = fields(ifile)
+   assert(name == 'bar' and tonumber(len) == 11)
+
+   os.remove('selftest')
+   os.remove('selftest.index')
+   print("ok")
+end
+
+shmem.selftest = selftest
+
+return shmem


### PR DESCRIPTION
I'd like to pick up on a suggestion for sharing counters with other processes by Luke in the thread 
https://groups.google.com/d/msg/snabb-devel/-Ka_gPfd88k/tL0wTqxcizcJ

I commented back then that I was thinking about something like that to implement an interface to a SNMP agent. I have done this by generalzing Luke's code from https://github.com/lukego/snabbswitch/blob/counter/src/core/counter.lua

I think that this (or something similar) might be worth adding to the Snabb core.

The "mib" subclass supports all basic SMIv2 types.  And, yes, I have working code for my VPN app and a SNMP sub-agent (written in Perl) that allows me to monitor my system with our standard monitoring system via SNMP (based on Nagios). I'm really pleased with that :)

I have also implemented Luke's "counter" module on top of it, which is a trivial extension of the shmem base class. The difference to his code, apart from using uint64 instead of double (open for discussion), is that he pre-allocates a memory region of a certain size and falls back to heap memory when it is exhausted, while my code starts with a zero-length mapping and extends it when new objects are registered. It will fail hard (assert)  when the underlying mmap() fails or there is a problem with the data or index file. Registering is expected to not be used in the fast path.

I suggest to put this under lib/ipc/shmem in anticipation of other IPC mechanisms that we may add in the future. But I don't have a strong opinion about where to put it.
