### PR TITLE
NFV config fuzz

### DIFF
--- a/src/designs/neutron/snabbnfv-fuzz
+++ b/src/designs/neutron/snabbnfv-fuzz
@@ -1,0 +1,19 @@
+#!/usr/bin/env snabb
+
+local lib  = require("core.lib")
+local fuzz = require("lib.nfv.fuzz")
+
+if #main.parameters ~= 2 then
+   print([[Usage: snabbnfv-fuzz <spec-file> <output-path>
+
+Generate random config with ports A and B which can communicate with each
+other over IPv6/TCP based on <spec-file> and write it to <output-path>.]])
+   main.exit(1)
+end
+
+function run (spec_path, output_path)
+   lib.store_conf(output_path,
+                  fuzz.fuzz_connective_ports(lib.load_conf(spec_path)))
+end
+
+run(unpack(main.parameters))

--- a/src/lib/nfv/fuzz.lua
+++ b/src/lib/nfv/fuzz.lua
@@ -1,0 +1,135 @@
+module(...,package.seeall)
+
+-- Produces a random config with ports A and B which can communicate with
+-- each other over IPv6/TCP based on spec.
+function fuzz_connective_ports (spec)
+   local vlan = random_vlan()
+   local addresses = { "fe80:0:0:0:5054:ff:fe00:0",
+                       "fe80:0:0:0:5054:ff:fe00:1" }
+   local ports = { { port_id = "A",
+                     mac_address = "52:54:00:00:00:00",
+                     vlan = vlan },
+                   { port_id = "B",
+                     mac_address = "52:54:00:00:00:01",
+                     vlan = vlan } }
+   local function fuzz_filter (n_rules)
+      local rules = {}
+      rules[1] = { ethertype="ipv6",
+                   protocol="tcp" }
+      rules[2] = { ethertype="ipv6",
+                   protocol="icmp" }
+      for i = 1, n_rules do
+         rules[i+2] = random_filter_rule()
+      end
+      return rules
+   end
+   local function fuzz_tunnel ()
+      local cookies = { random_cookie(), random_cookie() }
+      return { type = "L2TPv3",
+               local_cookie = cookies[1],
+               remote_cookie = cookies[2],
+               next_hop = addresses[2],
+               local_ip = addresses[1],
+               remote_ip = addresses[2],
+               session = random_session() },
+             { type = "L2TPv3",
+               local_cookie = cookies[2],
+               remote_cookie = cookies[1],
+               next_hop = addresses[1],
+               local_ip = addresses[2],
+               remote_ip = addresses[1],
+               session = random_session() }
+   end
+   if spec.ingress_filter then
+      ports[1].ingress_filter = fuzz_filter(spec.ingress_filter)
+      ports[2].ingress_filter = fuzz_filter(spec.ingress_filter)
+   end
+   if spec.egress_filter then 
+      ports[1].egress_filter = fuzz_filter(spec.egress_filter)
+      ports[2].egress_filter = fuzz_filter(spec.egress_filter)
+   end
+   if spec.tunnel then
+      ports[1].tunnel, ports[2].tunnel = fuzz_tunnel()
+   end
+   if spec.rx_police_gbps then
+      ports[1].rx_police_gbps = random_gbps(spec.rx_police_gbps)
+      ports[2].rx_police_gbps = random_gbps(spec.rx_police_gbps)
+   end
+   if spec.tx_police_gbps then
+      ports[1].tx_police_gbps = random_gbps(spec.tx_police_gbps)
+      ports[2].tx_police_gbps = random_gbps(spec.tx_police_gbps)
+   end
+   return ports
+end
+
+function random_uint (nbits, min)
+   return math.random(min or 0, (2^nbits-1))
+end
+
+function random_vlan ()
+   -- Twelve bit integer, see Intel10G (apps.intel.intel_app)
+   return random_uint(12)
+end
+
+function random_ip (version)
+   local version = version or "ipv6"
+   local function b4 () return random_uint(8) end
+   local function b6 () return ("%X"):format(random_uint(16)) end
+   if version == "ipv4" then
+      return b4().."."..b4().."."..b4().."."..b4()
+   elseif version == "ipv6" then
+      return b6()..":"..b6()..":"..b6()..":"..b6()..":"..b6()..":"..b6()..":"..b6()..":"..b6()
+   end
+end
+
+function random_cidr (version)
+   local version = version or "ipv6"
+   local max_prefix
+   if version == "ipv4" then
+      max_prefix = 32
+   elseif version == "ipv6" then
+      max_prefix = 128
+   end
+   return random_ip(version).."/"..math.random(0, max_prefix)
+end
+
+function random_port (min)
+   local min = min or 1024
+   return random_uint(16, min)
+end
+
+function random_item (array)
+   return array[math.random(1, #array)]
+end
+
+function random_filter_rule ()
+   local options = { ethertype = { "ipv4", "ipv6" },
+                     protocol = { "icmp", "udp", "tcp" } }
+   local ethertype = random_item(options.ethertype)
+   local source_port_min = random_port()
+   local dest_port_min = random_port()
+   -- See PacketFilter (apps.packet_filter.packet_filter)
+   return { ethertype = ethertype,
+            protocol = random_item(options.protocol),
+            source_cidr = random_cidr(ethertype),
+            dest_cidr = random_cidr(ethertype),
+            source_port_min = source_port_min,
+            source_port_max = random_port(source_port_min),
+            dest_port_min = dest_port_min,
+            source_port_max = random_port(dest_port_min) }
+end
+
+function random_cookie ()
+   local function b() return ("%X"):format(random_uint(8)) end
+   -- Eight byte hex string, see SimpleKeyedTunnel (apps.keyed_ipv6_tunnel.tunnel)
+   return b()..b()..b()..b()..b()..b()..b()..b()
+end
+
+function random_session ()
+   -- 32 bit uint, see SimpleKeyedTunnel (apps.keyed_ipv6_tunnel.tunnel)
+   return random_uint(32)
+end
+
+function random_gbps (max_gbps)
+   return math.random(1, max_gbps)
+end

--- a/src/lib/nfv/selftest.sh
+++ b/src/lib/nfv/selftest.sh
@@ -228,6 +228,18 @@ function filter_tests {
     assert FILTER $?
 }
 
+# Usage: fuzz_tests <n>
+# Generate and test (IPERF) <n> semi-random NFV configurations.
+function fuzz_tests {
+    for ((n=0;n<$1;n++)); do
+        $SNABB designs/neutron/snabbnfv-fuzz \
+            test_fixtures/nfvconfig/fuzz/filter2-tunnel-txrate10-ports.spec \
+            /tmp/snabb_nfv_selftest_fuzz.ports
+        load_config /tmp/snabb_nfv_selftest_fuzz.ports
+        test_iperf $TELNET_PORT0 $TELNET_PORT1 "$GUEST_IP1%eth0"
+    done
+}
+
 load_config test_fixtures/nfvconfig/test_functions/other_vlan.ports
 start_bench_env
 
@@ -235,5 +247,6 @@ same_vlan_tests
 rate_limited_tests
 tunnel_tests
 filter_tests
+#fuzz_tests 100
 
 stop_bench_env

--- a/src/test_fixtures/nfvconfig/fuzz/filter2-tunnel-txrate10-ports.spec
+++ b/src/test_fixtures/nfvconfig/fuzz/filter2-tunnel-txrate10-ports.spec
@@ -1,0 +1,4 @@
+return { ingress_filter = 2,
+         egress_filter = 2,
+         tunnel = true,
+         tx_police_gbps = 10 }


### PR DESCRIPTION
This adds a fuzzing function to the NFV selftest. The fuzzer generates semi-random NFV configurations that allow a successful `iperf` run between two VMs to test the configuration. The fuzzer's output can be controlled using a "spec" file which might look like this:

```
return { ingress_filter = 2, -- generate two random ingress filter rules (in addition to rules for iperf)
 egress_filter = 2, -- generate two random egress filter rules (in addition to rules for iperf)
 tunnel = true, -- do generate a tunnel config
 tx_police_gbps = 10 } -- do generate random value 1...10 (rx_police_gbps is also recognized)
```

If a key is omitted or `nil` then the config part in question is omitted.