### PR TITLE
Rename snabbfv-traffic's rx_police_gbps to tx_police_gbps and add proper rx_police_gbps

### DIFF
--- a/src/lib/nfv/README.md
+++ b/src/lib/nfv/README.md
@@ -39,7 +39,7 @@ port := { port_id        = <id>,          -- A unique string
           ingress_filter = <rules>,       -- As for PacketFilter
           egress_filter  = <rules>,       -- ..
           tunnel         = <tunnel-conf>,
-          rx_police_gbps = <n> }          -- Allowed rate in Gbps
+          tx_police_gbps = <n> }          -- Allowed output rate in Gbps
 ```
 
 The `tunnel` section deviates a little from `SimpleKeyedTunnel`'s

--- a/src/lib/nfv/README.md
+++ b/src/lib/nfv/README.md
@@ -39,6 +39,7 @@ port := { port_id        = <id>,          -- A unique string
           ingress_filter = <rules>,       -- As for PacketFilter
           egress_filter  = <rules>,       -- ..
           tunnel         = <tunnel-conf>,
+          rx_police_gbps = <n>,           -- Allowed input rate in Gbps
           tx_police_gbps = <n> }          -- Allowed output rate in Gbps
 ```
 

--- a/src/lib/nfv/README.md.src
+++ b/src/lib/nfv/README.md.src
@@ -51,7 +51,7 @@ port := { port_id        = <id>,          -- A unique string
           ingress_filter = <rules>,       -- As for PacketFilter
           egress_filter  = <rules>,       -- ..
           tunnel         = <tunnel-conf>,
-          rx_police_gbps = <n> }          -- Allowed rate in Gbps
+          tx_police_gbps = <n> }          -- Allowed output rate in Gbps
 ```
 
 The `tunnel` section deviates a little from `SimpleKeyedTunnel`'s

--- a/src/lib/nfv/README.md.src
+++ b/src/lib/nfv/README.md.src
@@ -51,6 +51,7 @@ port := { port_id        = <id>,          -- A unique string
           ingress_filter = <rules>,       -- As for PacketFilter
           egress_filter  = <rules>,       -- ..
           tunnel         = <tunnel-conf>,
+          rx_police_gbps = <n>,           -- Allowed input rate in Gbps
           tx_police_gbps = <n> }          -- Allowed output rate in Gbps
 ```
 

--- a/src/lib/nfv/config.lua
+++ b/src/lib/nfv/config.lua
@@ -66,9 +66,9 @@ function load (file, pciaddr, sockpath)
          config.link(c, Tunnel..".decapsulated -> "..VM_rx)
          VM_rx, VM_tx = ND..".south", ND..".south"
       end
-      if t.rx_police_gbps then
+      if t.tx_police_gbps then
          local QoS = "QoS_"..name
-         local rate = t.rx_police_gbps * 1e9 / 8
+         local rate = t.tx_police_gbps * 1e9 / 8
          config.app(c, QoS, RateLimiter, {rate = rate, bucket_capacity = rate})
          config.link(c, VM_tx.." -> "..QoS..".input")
          VM_tx = QoS..".output"

--- a/src/test_fixtures/nfvconfig/test_functions/rx_rate_limit.ports
+++ b/src/test_fixtures/nfvconfig/test_functions/rx_rate_limit.ports
@@ -1,0 +1,16 @@
+return {
+  { vlan = 43,
+    mac_address = "52:54:00:00:00:00",
+    port_id = "A",
+    ingress_filter = nil,
+    rx_police_gbps = 1,
+    tunnel = nil
+  },
+  { vlan = 43,
+    mac_address = "52:54:00:00:00:01",
+    port_id = "B",
+    ingress_filter = nil,
+    rx_police_gbps = 1,
+    tunnel = nil
+  },
+}

--- a/src/test_fixtures/nfvconfig/test_functions/tx_rate_limit.ports
+++ b/src/test_fixtures/nfvconfig/test_functions/tx_rate_limit.ports
@@ -3,14 +3,14 @@ return {
     mac_address = "52:54:00:00:00:00",
     port_id = "A",
     ingress_filter = nil,
-    rx_police_gbps = 0.5,
+    tx_police_gbps = 0.5,
     tunnel = nil
   },
   { vlan = 43,
     mac_address = "52:54:00:00:00:01",
     port_id = "B",
     ingress_filter = nil,
-    rx_police_gbps = 1.5,
+    tx_police_gbps = 0.5,
     tunnel = nil
   },
 }


### PR DESCRIPTION
Rename snabbfv-traffic's rx_police_gbps to tx_police_gbps and add proper rx_police_gbps. I started a mailing list thread about my woes actually testing rate limiting but I believe solving these is not in the scope of this PR. Nevertheless this branch extends the NFV selftest with a function `test_rate_limited` that allows testing of effective rate limiting. This functions is used to test the changes for ballpark sanity.
