### PR TITLE
Make ./snabb binary more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COBJ   = $(CSRC:.c=.o)
 
 LUAJIT_O := deps/luajit/src/libluajit.a
 
-LUAJIT_CFLAGS := -DLUAJIT_USE_PERFTOOLS -DLUAJIT_USE_GDBJIT -DLUAJIT_NUMMODE=3
+LUAJIT_CFLAGS := -DLUAJIT_USE_PERFTOOLS -DLUAJIT_USE_GDBJIT -DLUAJIT_NUMMODE=3 -include $(CURDIR)/gcc-preinclude.h
 
 all: $(LUAJIT_O)
 	cd src && $(MAKE)

--- a/gcc-preinclude.h
+++ b/gcc-preinclude.h
@@ -1,6 +1,8 @@
 // Force an old symbol version on memcpy.
 // See: http://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html
 //      https://rjpower9000.wordpress.com/2012/04/09/fun-with-shared-libraries-version-glibc_2-14-not-found/
-__asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
 
+#ifndef __ASSEMBLER__
+__asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
+#endif
 

--- a/gcc-preinclude.h
+++ b/gcc-preinclude.h
@@ -1,0 +1,6 @@
+// Force an old symbol version on memcpy.
+// See: http://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html
+//      https://rjpower9000.wordpress.com/2012/04/09/fun-with-shared-libraries-version-glibc_2-14-not-found/
+__asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
+
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,7 +45,7 @@ snabb: $(LUAOBJ) $(HOBJ) $(COBJ) $(ASMOBJ)
 	$(E) "LINK      $@"
 	$(Q) gcc -Wl,--no-as-needed -Wl,-E -Werror -Wall -o $@ $^ \
 	    ../deps/luajit/src/libluajit.a \
-	    -lc -ldl -lm -lrt -lpthread
+	    -lrt -lc -ldl -lm -lpthread
 	@echo -n "Firmware: "
 	@ln -fs snabb snabbswitch
 	@ls -sh snabb
@@ -99,7 +99,7 @@ $(LUAOBJ): obj/%_lua.o: %.lua Makefile | $(OBJDIR)
 
 $(COBJ): obj/%_c.o: %.c $(CHDR) Makefile | $(OBJDIR)
 	$(E) "C         $@"
-	$(Q) gcc -Wl,-E -I ../deps/luajit/src -I . -c -Wall -Werror -o $@ $<
+	$(Q) gcc -Wl,-E -I ../deps/luajit/src -I . -include $(CURDIR)/../gcc-preinclude.h -c -Wall -Werror -o $@ $<
 
 $(HOBJ): obj/%_h.o: %.h Makefile | $(OBJDIR)
 	$(E) "H         $@"

--- a/src/selftest.sh
+++ b/src/selftest.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 echo "selftest: ./snabb binary portability"
-glibc=$(objdump -T snabb | grep GLIBC | sed -e 's/^.*GLIBC_//' -e 's/ .*//' | sort -nr | head -1)
-if [ "$glibc" == "2.7" ]; then
-    echo "ok: links with glibc >= 2.7"
-else
-    echo "error: requires glibc $glibc (> 2.7)"
+echo "Scanning for symbols requiring GLIBC > 2.7"
+if objdump -T snabb | \
+   awk '/GLIBC/ { print $(NF-1), $NF }' | \
+   grep -v 'GLIBC_2\.[0-7][\. ]'; then
+    echo "^^^ Error ^^^" >&2
+    echo "(You might just need to 'make clean; make' at the top level.)"
     exit 1
 fi
+echo "selftest: ok"

--- a/src/selftest.sh
+++ b/src/selftest.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "selftest: ./snabb binary portability"
+glibc=$(objdump -T snabb | grep GLIBC | sed -e 's/^.*GLIBC_//' -e 's/ .*//' | sort -nr | head -1)
+if [ "$glibc" == "2.7" ]; then
+    echo "ok: links with glibc >= 2.7"
+else
+    echo "error: requires glibc $glibc (> 2.7)"
+    exit 1
+fi


### PR DESCRIPTION
Prepare dynamic linking so that `./snabb` is compatible with all GLIBC versions >= 2.7. This enables us to release Snabb Switch as a single executable file for any modern Linux/x86_64.

Tested when built on Ubuntu 14.04. Building with newer versions of GLIBC can potentially break backwards compatibility. A `selftest.sh` script is included to detect this.

Makefile now forces GCC to always include the file `gcc-preinclude.h`. This file can contain `.symver` directives to break dependencies on new GLIBC versions.

There is currently one such directive forcing `memcpy` to bind to the GLIBC 2.2.5 symbol instead of GLIBC 2.14. (This is because GLIBC made a semi-backwards-incompatible change to `memcpy` in version 2.14.) Loosely speaking, this has the side-effect of forcing `memcpy` to act like `memmove` i.e. to be safe for overlapping memory regions. This is not expected to have a significant performance impact, although that is not impossible. See [long question](https://sourceware.org/ml/libc-alpha/2015-02/msg00044.html) to the GLIBC mailing list about this (unanswered).