### PR TITLE
Intel10G: better initialization / closing

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -93,6 +93,25 @@ function M_sf:init ()
 end
 
 
+function M_sf:recheck()
+   local mask = bits{Link_up=30}
+   if band(self.r.LINKS(), mask) == mask then
+      return self
+   else
+      return self
+         :disable_interrupts()
+         :global_reset()
+         :wait_eeprom_autoread()
+         :wait_dma()
+         :init_statistics()
+         :init_receive()
+         :init_transmit()
+         :wait_enable()
+         :wait_linkup()
+   end
+end
+
+
 function M_sf:init_dma_memory ()
    self.rxdesc, self.rxdesc_phy =
       memory.dma_alloc(num_descriptors * ffi.sizeof(rxdesc_t))
@@ -321,7 +340,7 @@ function M_sf:wait_linkup ()
       C.usleep(1000)
    end
    io.write ('never got link up: ', self.pciaddress, '\n')
-   return self
+   return self:recheck()
 end
 
 --- ### Status and diagnostics
@@ -446,6 +465,25 @@ function M_pf:init ()
       :init_receive()
       :init_transmit()
       :wait_linkup()
+end
+
+function M_pf:recheck()
+   local mask = bits{Link_up=30}
+   if band(self.r.LINKS(), mask) == mask then
+      return self
+   else
+      return self
+         :disable_interrupts()
+         :global_reset()
+         :autonegotiate_sfi()
+         :wait_eeprom_autoread()
+         :wait_dma()
+         :set_vmdq_mode()
+         :init_statistics()
+         :init_receive()
+         :init_transmit()
+         :wait_linkup()
+   end
 end
 
 M_pf.close = M_sf.close

--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -340,7 +340,7 @@ function M_sf:wait_linkup ()
       C.usleep(1000)
    end
    io.write ('never got link up: ', self.pciaddress, '\n')
-   return self:recheck()
+   return self
 end
 
 --- ### Status and diagnostics
@@ -465,6 +465,7 @@ function M_pf:init ()
       :init_receive()
       :init_transmit()
       :wait_linkup()
+      :recheck()
 end
 
 function M_pf:recheck()

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -39,7 +39,6 @@ function Intel82599:new (arg)
    else
       local dev = intel10g.new_sf(conf.pciaddr)
          :open()
-         :autonegotiate_sfi()
          :wait_linkup()
       if not dev then return null end
       return setmetatable({dev=dev, zone="intel"}, Intel82599)
@@ -160,7 +159,7 @@ function selftest ()
 
    zone('buffer') buffer.preallocate(1000) zone()
 
-   manyreconf(pcideva, pcidevb)
+--    manyreconf(pcideva, pcidevb)
 
    mq_sw(pcideva)
    engine.main({duration = 1, report={showlinks=true, showapps=false}})
@@ -350,7 +349,7 @@ function manyreconf(pcidevA, pcidevB)
       26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35
       36 37
    ]], 98)                  -- src: Am0    dst: ---
-   engine.configure(config.new())
+--    engine.configure(config.new())
    local prevsent = 0
    for i = 1, 100 do
       print (('config #%d'):format(i))
@@ -382,7 +381,7 @@ function manyreconf(pcidevA, pcidevB)
       engine.configure(c)
       link.transmit(engine.app_table.source_ms.output.out, packet.from_data(d1))
       link.transmit(engine.app_table.source_ms.output.out, packet.from_data(d2))
-      engine.main({duration = 0.25, report={showlinks=true, showapps=true}})
+      engine.main({duration = 0.25, report={showlinks=true, showapps=false}})
       local sent = engine.app_table.nicAm0.input.rx.stats.txpackets
       if sent == prevsent then
          os.exit(2)

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -40,6 +40,7 @@ function Intel82599:new (arg)
       local dev = intel10g.new_sf(conf.pciaddr)
          :open()
          :wait_linkup()
+         :recheck()
       if not dev then return null end
       return setmetatable({dev=dev, zone="intel"}, Intel82599)
    end
@@ -159,7 +160,7 @@ function selftest ()
 
    zone('buffer') buffer.preallocate(1000) zone()
 
---    manyreconf(pcideva, pcidevb)
+   manyreconf(pcideva, pcidevb)
 
    mq_sw(pcideva)
    engine.main({duration = 1, report={showlinks=true, showapps=false}})

--- a/src/lib/hardware/pci.c
+++ b/src/lib/hardware/pci.c
@@ -54,9 +54,14 @@ uint32_t volatile *map_pci_resource(int fd)
   }
 }
 
-void close_pci_resource(int fd)
+void close_pci_resource(int fd, uint32_t volatile *addr)
 {
   flock(fd, LOCK_UN);
+  if (addr != NULL) {
+    struct stat st;
+    assert( fstat(fd, &st) == 0 );
+    assert( munmap((void *)addr, st.st_size) == 0 );
+  }
   close(fd);
 }
 

--- a/src/lib/hardware/pci.h
+++ b/src/lib/hardware/pci.h
@@ -1,4 +1,4 @@
 int open_pci_resource(const char *path);
-void close_pci_resource(int fd);
+void close_pci_resource(int fd, uint32_t volatile *addr);
 uint32_t volatile *map_pci_resource(int fd);
 int open_pcie_config(const char *path);

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -92,8 +92,8 @@ end
 
 -- Close a file descriptor opened by map_pci_memory().
 -- XXX should also unmap the memory.
-function close_pci_resource (fd)
-   C.close_pci_resource(fd)
+function close_pci_resource (fd, base)
+   C.close_pci_resource(fd, base)
 end
 
 --- Enable or disable PCI bus mastering. DMA only works when bus


### PR DESCRIPTION
- unmaps PCI resource on device close
- deallocates buffers on (vf) app close
- don't (always) force sfi mode, autonegotiation handles this.
- if the link doesn't come up, reset the chip and try once more.

The last point in particular made _all_ cards on both davos and grindelwald pass all tests.  I couldn't test on chur because it's all tied up in some long-term process.

No more "flaky hardware" excuses!