### PR TITLE
Rudimentary support of the ifTable MIB for intel10g

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -15,6 +15,8 @@ local pci      = require("lib.hardware.pci")
 local register = require("lib.hardware.register")
 local index_set = require("lib.index_set")
 local macaddress = require("lib.macaddress")
+local mib = require("lib.ipc.shmem.mib")
+local timer = require("core.timer")
 
 local bits, bitset = lib.bits, lib.bitset
 local band, bor, lshift = bit.band, bit.bor, bit.lshift
@@ -23,6 +25,8 @@ local packet_ref = packet.ref
 num_descriptors = 32 * 1024
 --num_descriptors = 32
 
+-- Timer for interface status check in seconds
+status_timer = 5
 
 local function pass (...) return ... end
 
@@ -49,7 +53,6 @@ function new_sf (pciaddress)
               }
    return setmetatable(dev, M_sf)
 end
-
 
 function M_sf:open ()
    pci.set_bus_master(self.pciaddress, true)
@@ -81,6 +84,7 @@ end
 
 function M_sf:init ()
    return self
+      :init_snmp()
       :init_dma_memory()
       :disable_interrupts()
       :global_reset()
@@ -92,6 +96,45 @@ function M_sf:init ()
       :wait_enable()
 end
 
+
+function M_sf:init_snmp ()
+   -- Rudimentary population of a row in the ifTable MIB.  Allocation
+   -- of the ifIndex is delegated to the SNMP agent via the name of
+   -- the interface in ifDescr (currently the PCI address).
+   local ifTable = mib:new({ filename = self.pciaddress })
+   ifTable:register('ifDescr', 'OctetStr', self.pciaddress)
+   ifTable:register('ifAdminStatus', 'Integer32', 1) -- up
+   ifTable:register('ifOperStatus', 'Integer32', 2) -- down
+   ifTable:register('ifLastChange', 'TimeTicks', 0)
+   ifTable:register('_X_ifLastChange_TicksBase', 'Counter64', C.get_unix_time())
+   ifTable:register('ifType', 'Integer32', 6) -- ethernetCsmacd
+   ifTable:register('ifSpeed', 'Gauge32', 10000000)
+
+   -- Create a timer to periodically check the interface status.  The
+   -- default interval is 5 seconds, defined by the status_timer
+   -- variable.
+   local status = { [1] = 'up', [2] = 'down' }
+   local t = timer.new("Interface "..self.pciaddress.." status checker",
+		       function(t)
+			  local old = ifTable:get('ifOperStatus')
+			  local mask = bits{Link_up=30}
+			  local new = 1
+			  if band(self.r.LINKS(), mask) ~= mask then
+			     new = 2
+			  end
+			  if old ~= new then
+			     print("Interface "..self.pciaddress..
+				   " status change: "..status[old]..
+				   " => "..status[new])
+			     ifTable:set('ifOperStatus', new)
+			     ifTable:set('ifLastChange', 0)
+			     ifTable:set('_X_ifLastChange_TicksBase',
+				     C.get_unix_time())
+			  end
+		       end, 1e9 * status_timer, 'repeating')
+   timer.activate(t)
+   return self
+end
 
 function M_sf:init_dma_memory ()
    self.rxdesc, self.rxdesc_phy =
@@ -436,6 +479,7 @@ end
 
 function M_pf:init ()
    return self
+      :init_snmp()
       :disable_interrupts()
       :global_reset()
       :autonegotiate_sfi()
@@ -448,6 +492,7 @@ function M_pf:init ()
       :wait_linkup()
 end
 
+M_pf.init_snmp = M_sf.init_snmp
 M_pf.close = M_sf.close
 M_pf.global_reset = M_sf.global_reset
 M_pf.disable_interrupts = M_sf.disable_interrupts


### PR DESCRIPTION
To be useful in the Real World, I need some way of monitoring the status of an interface. This PR uses the shared memory IPC construct to populate a row in the regular interface MIB for each instance of the intel10g driver. The status is checked every 5 seconds.

To make use of it, one needs an SNMP (sub-)agent that supports the semantics of the shmem module. I have such a beast (coming soon to a Git repository near you) and this is how a table walk looks like on my test system with two active interfaces:

IF-MIB::ifDescr.1 = STRING: 0000:04:00.0
IF-MIB::ifDescr.2 = STRING: 0000:04:00.1
IF-MIB::ifType.1 = INTEGER: ethernetCsmacd(6)
IF-MIB::ifType.2 = INTEGER: ethernetCsmacd(6)
IF-MIB::ifSpeed.1 = Gauge32: 10000000
IF-MIB::ifSpeed.2 = Gauge32: 10000000
IF-MIB::ifAdminStatus.1 = INTEGER: up(1)
IF-MIB::ifAdminStatus.2 = INTEGER: up(1)
IF-MIB::ifOperStatus.1 = INTEGER: up(1)
IF-MIB::ifOperStatus.2 = INTEGER: up(1)
IF-MIB::ifLastChange.1 = Timeticks: (1200) 0:00:12.00
IF-MIB::ifLastChange.2 = Timeticks: (1200) 0:00:12.00

The ifOperStatus changes when I shut down the interface on the attached host (or unplug the cable) and even the timers work correctly :)

IF-MIB::ifDescr.1 = STRING: 0000:04:00.0
IF-MIB::ifDescr.2 = STRING: 0000:04:00.1
IF-MIB::ifType.1 = INTEGER: ethernetCsmacd(6)
IF-MIB::ifType.2 = INTEGER: ethernetCsmacd(6)
IF-MIB::ifSpeed.1 = Gauge32: 10000000
IF-MIB::ifSpeed.2 = Gauge32: 10000000
IF-MIB::ifAdminStatus.1 = INTEGER: up(1)
IF-MIB::ifAdminStatus.2 = INTEGER: up(1)
IF-MIB::ifOperStatus.1 = INTEGER: down(2)
IF-MIB::ifOperStatus.2 = INTEGER: up(1)
IF-MIB::ifLastChange.1 = Timeticks: (300) 0:00:03.00
IF-MIB::ifLastChange.2 = Timeticks: (4300) 0:00:43.00

It would be fairly easy to include traffic counters directly through this MIB but I'm not sure if this is the way to go.

I use our current convention to identify an interface by its PCI address.