### PR TITLE
Add ljsyscall to Snabb Switch [DRAFT]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ obj
 /src/testlog
 /src/apps/ipv6/selftest.cap.output
 /src/apps/keyed_ipv6_tunnel/selftest.cap.output
+/src/syscall.lua
+/src/syscall

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = deps/luajit
 	url = http://luajit.org/git/luajit-2.0.git
         ignore = dirty
+[submodule "deps/ljsyscall"]
+	path = deps/ljsyscall
+	url = https://github.com/justincormack/ljsyscall.git

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ CSRC   = $(wildcard src/c/*.c)
 COBJ   = $(CSRC:.c=.o)
 
 LUAJIT_O := deps/luajit/src/libluajit.a
+SYSCALL  := src/syscall.lua
 
 LUAJIT_CFLAGS := -DLUAJIT_USE_PERFTOOLS -DLUAJIT_USE_GDBJIT -DLUAJIT_NUMMODE=3
 
-all: $(LUAJIT_O)
+all: $(LUAJIT_O) $(SYSCALL)
 	cd src && $(MAKE)
 
 install: all
@@ -34,8 +35,22 @@ check_luajit:
 	    echo "Can't find deps/luajit/. You might need to: git submodule update --init"; exit 1; \
 	fi
 
+$(SYSCALL): check_syscall
+	echo 'Copying ljsyscall components'
+	mkdir -p src/syscall/linux
+	cp -p deps/ljsyscall/syscall.lua   src/
+	cp -p deps/ljsyscall/syscall/*.lua src/syscall/
+	cp -p  deps/ljsyscall/syscall/linux/*.lua src/syscall/linux/
+	cp -pr deps/ljsyscall/syscall/linux/x64   src/syscall/linux/
+	cp -pr deps/ljsyscall/syscall/shared      src/syscall/
+
+check_syscall:
+	@if [ ! -f deps/ljsyscall/syscall.lua ]; then \
+	    echo "Can't find deps/ljsyscall/. You might need to: git submodule update --init"; exit 1; \
+	fi
+
 clean:
 	(cd deps/luajit && $(MAKE) clean)
-	(cd src; $(MAKE) clean)
+	(cd src; $(MAKE) clean; rm -rf syscall.lua syscall)
 
 .SERIAL: all


### PR DESCRIPTION
This will enable us to rewrite most of our C glue code in Lua.

ljsyscall is an extensive LuaJIT FFI interface towards the kernel:
  https://github.com/justincormack/ljsyscall

The source code is added as a submodule in deps/ljsyscall.

The top-level Makefile copies required source files directly into
src/. Only the code for Linux/x86-64 is imported.

The top-level .gitignore file matches on the copied files.