### PR TITLE
Intel10G: extensive reconfig tests and better initalization

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -80,25 +80,12 @@ end
 --- See data sheet section 4.6.3 "Initialization Sequence."
 
 function M_sf:init ()
-   return self
-      :init_dma_memory()
-      :disable_interrupts()
-      :global_reset()
-      :wait_eeprom_autoread()
-      :wait_dma()
-      :init_statistics()
-      :init_receive()
-      :init_transmit()
-      :wait_enable()
-end
+   self :init_dma_memory()
 
-
-function M_sf:recheck()
+   self.redos = 0
    local mask = bits{Link_up=30}
-   if band(self.r.LINKS(), mask) == mask then
-      return self
-   else
-      return self
+   for i = 1, 5 do
+      self
          :disable_interrupts()
          :global_reset()
          :wait_eeprom_autoread()
@@ -108,8 +95,16 @@ function M_sf:recheck()
          :init_transmit()
          :wait_enable()
          :wait_linkup()
+
+      if band(self.r.LINKS(), mask) == mask then
+         self.redos = i
+         return self
+      end
    end
+   io.write ('never got link up: ', self.pciaddress)
+   return self
 end
+
 
 do
    local _rx_pool = {}
@@ -261,7 +256,7 @@ function M_sf:discard_unsent_packets()
    self.r.TDT(self.tdh)
    while old_tdt ~= self.tdh do
       old_tdt = band(old_tdt - 1, num_descriptors - 1)
-      packet.deref(self.txpackets[old_tdt])
+      packet.free(self.txpackets[old_tdt])
       self.txdesc[old_tdt].address = 0
       self.txdesc[old_tdt].options = 0
    end
@@ -316,14 +311,16 @@ function M_sf:sync_receive ()
 end
 
 function M_sf:wait_linkup ()
+   self.waitlu_ms = 0
    local mask = bits{Link_up=30}
-   for count = 1, 500 do
+   for count = 1, 250 do
       if band(self.r.LINKS(), mask) == mask then
+         self.waitlu_ms = count
          return self
       end
       C.usleep(1000)
    end
-   io.write ('never got link up: ', self.pciaddress, '\n')
+   self.waitlu_ms = 250
    return self
 end
 
@@ -438,29 +435,12 @@ function M_pf:close()
 end
 
 function M_pf:init ()
-   return self
-      :disable_interrupts()
-      :global_reset()
-      :autonegotiate_sfi()
-      :wait_eeprom_autoread()
-      :wait_dma()
-      :set_vmdq_mode()
-      :init_statistics()
-      :init_receive()
-      :init_transmit()
-      :wait_linkup()
-      :recheck()
-end
-
-function M_pf:recheck()
+   self.redos = 0
    local mask = bits{Link_up=30}
-   if band(self.r.LINKS(), mask) == mask then
-      return self
-   else
-      return self
+   for i = 1, 5 do
+      self
          :disable_interrupts()
          :global_reset()
-         :autonegotiate_sfi()
          :wait_eeprom_autoread()
          :wait_dma()
          :set_vmdq_mode()
@@ -468,7 +448,13 @@ function M_pf:recheck()
          :init_receive()
          :init_transmit()
          :wait_linkup()
+      if band(self.r.LINKS(), mask) == mask then
+         return self
+      end
+      self.redos = i
    end
+   io.write ('gave up\n')
+   return self
 end
 
 M_pf.global_reset = M_sf.global_reset

--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -437,10 +437,13 @@ end
 function M_pf:init ()
    self.redos = 0
    local mask = bits{Link_up=30}
-   for i = 1, 5 do
+   for i = 1, 10 do
+      io.write (self.pciaddress, 'init #', i, '\n')
       self
          :disable_interrupts()
          :global_reset()
+      if i == 5 then self:autonegotiate_sfi() end
+      self
          :wait_eeprom_autoread()
          :wait_dma()
          :set_vmdq_mode()

--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -84,10 +84,12 @@ function M_sf:init ()
 
    self.redos = 0
    local mask = bits{Link_up=30}
-   for i = 1, 5 do
+   for i = 1, 100 do
       self
          :disable_interrupts()
          :global_reset()
+      if i%5 == 0 then self:autonegotiate_sfi() end
+      self
          :wait_eeprom_autoread()
          :wait_dma()
          :init_statistics()
@@ -101,7 +103,8 @@ function M_sf:init ()
          return self
       end
    end
-   io.write ('never got link up: ', self.pciaddress)
+   io.write ('never got link up: ', self.pciaddress, '\n')
+   os.exit(2)
    return self
 end
 
@@ -437,12 +440,11 @@ end
 function M_pf:init ()
    self.redos = 0
    local mask = bits{Link_up=30}
-   for i = 1, 10 do
-      io.write (self.pciaddress, 'init #', i, '\n')
+   for i = 1, 100 do
       self
          :disable_interrupts()
          :global_reset()
-      if i == 5 then self:autonegotiate_sfi() end
+      if i%5 == 0 then self:autonegotiate_sfi() end
       self
          :wait_eeprom_autoread()
          :wait_dma()
@@ -456,7 +458,8 @@ function M_pf:init ()
       end
       self.redos = i
    end
-   io.write ('gave up\n')
+   io.write ('never got link up: ', self.pciaddress, '\n')
+   os.exit(2)
    return self
 end
 

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -143,7 +143,10 @@ function selftest ()
       os.exit(engine.test_skipped_code)
    end
 
-   manyreconf(pcideva, pcidevb)
+   print ("100 VF initializations:")
+   manyreconf(pcideva, pcidevb, 100, false)
+   print ("100 PF full cycles")
+   manyreconf(pcideva, pcidevb, 100, true)
 
    mq_sw(pcideva)
    engine.main({duration = 1, report={showlinks=true, showapps=false}})
@@ -312,7 +315,7 @@ function mq_sw(pcidevA)
    link.transmit(engine.app_table.source_ms.output.out, packet.from_string(d2))
 end
 
-function manyreconf(pcidevA, pcidevB)
+function manyreconf(pcidevA, pcidevB, n, do_pf)
    io.write ('\n')
    local d1 = lib.hexundump ([[
       52:54:00:02:02:02 52:54:00:01:01:01 08 00 45 00
@@ -336,7 +339,7 @@ function manyreconf(pcidevA, pcidevB)
    local prevsent = 0
    local cycles, redos, maxredos, waits = 0, 0, 0, 0
    io.write("Running iterated VMDq test...\n")
-   for i = 1, 100 do
+   for i = 1, (n or 100) do
       local c = config.new()
       config.app(c, 'source_ms', basic_apps.Join)
       config.app(c, 'repeater_ms', basic_apps.Repeater)
@@ -359,7 +362,7 @@ function manyreconf(pcidevA, pcidevB)
       config.link(c, 'repeater_ms.output -> nicAm0.rx')
       config.link(c, 'nicAm0.tx -> sink_ms.in1')
       config.link(c, 'nicAm1.tx -> sink_ms.in2')
-      engine.configure(config.new())
+      if do_pf then engine.configure(config.new()) end
       engine.configure(c)
       link.transmit(engine.app_table.source_ms.output.out, packet.from_string(d1))
       link.transmit(engine.app_table.source_ms.output.out, packet.from_string(d2))


### PR DESCRIPTION
1. The `manyreconf()` function does two different tests: "VF-only": a hundred reconfiguration cycles for the same apps, the hardware is mostly set up once.  and "full PF cycle": a hundred full tear-down and reinitialization cycles.  Now the `selftest` does both.

1. The `autonegotiate_sfi()` was shown to do more harm than good when not needed, so it's now an optional part of the initialization.

1. When everything is going well, the NIC is initialized in typically 160msec, so the timeout is now 250msec, as per the Intel docs (down from 500).

1. If the NIC isn't up after 250msec, we reinitialize it, and in the vast majority of cases (well over 98%) it's done in 150-180msec.

1. In a few cases it won't come up until we do an `autonegotiate_sfi()`.  After that, it behaves normally.

1. Some cards work most of the time on the first init, some always need exactly one reinit.

1. A few cards (notably :03: in grindelwald) do work consistently at one reinit most of the time, but sometimes it needs many more reinits (with `autonegotiate_sfi()` every five reinits).  Eventually it does come up and work normally.  Typically after 24-28 reinits, a few times it took ~60 reinits, once it was 87!  In every case it did work and then a few hundred times more with exactly one reinit.

In short, the initialization is a lot faster most of the time, and when needed, it does a few extra tricks automatically and always gets it to work.  I've run the full test (with over 100 reconfigs of each type) 500 times in a row with the most troublesome card and it didn't gave up even once.