### PR TITLE
lib.hardware.* improvements

### DIFF
--- a/src/apps/intel/README.md
+++ b/src/apps/intel/README.md
@@ -121,6 +121,11 @@ dropped.
 
 ![LoadGen](.images/LoadGen.png)
 
+### Configuration
+
+The `LoadGen` app accepts a string as its configuration argument. The
+given string denotes the PCI address of the NIC to use.
+
 ### Performance
 
 The `LoadGen` app can transmit at line-rate (14 Mpps) without significant

--- a/src/apps/intel/README.md.src
+++ b/src/apps/intel/README.md.src
@@ -131,6 +131,11 @@ dropped.
                |          |
                +----------+
 
+### Configuration
+
+The `LoadGen` app accepts a string as its configuration argument. The
+given string denotes the PCI address of the NIC to use.
+
 ### Performance
 
 The `LoadGen` app can transmit at line-rate (14 Mpps) without significant

--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -64,6 +64,7 @@ function M_sf:open ()
 end
 
 function M_sf:close()
+   pci.set_bus_master(self.pciaddress, false)
    if self.free_receive_buffers then
       self:free_receive_buffers()
    end
@@ -433,6 +434,7 @@ function M_pf:open ()
 end
 
 function M_pf:close()
+   pci.set_bus_master(self.pciaddress, false)
    if self.fd then
       pci.close_pci_resource(self.fd, self.base)
       self.fd = false

--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -51,6 +51,7 @@ end
 
 
 function M_sf:open ()
+   pci.unbind_device_from_linux(self.pciaddress)
    pci.set_bus_master(self.pciaddress, true)
    self.base, self.fd = pci.map_pci_memory(self.pciaddress, 0)
    register.define(config_registers_desc, self.r, self.base)
@@ -420,6 +421,7 @@ function new_pf (pciaddress)
 end
 
 function M_pf:open ()
+   pci.unbind_device_from_linux(self.pciaddress)
    pci.set_bus_master(self.pciaddress, true)
    self.base, self.fd = pci.map_pci_memory(self.pciaddress, 0)
    register.define(config_registers_desc, self.r, self.base)

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -112,7 +112,7 @@ end
 -- Report on relevant status and statistics.
 function Intel82599:report ()
    print("report on intel device", self.dev.pciaddress or self.dev.pf.pciaddress)
-   register.dump(self.dev.s, true)
+   register.dump(self.dev.s)
    if self.dev.rxstats then
       for name,v in pairs(self.dev:get_rxstats()) do
          io.write(string.format('%30s: %d\n', 'rx '..name, v))

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -28,9 +28,6 @@ end
 function Intel82599:new (arg)
    local conf = config.parse_app_arg(arg)
 
-   -- Unbind PCI device form linux.
-   pci.unbind_device_from_linux(conf.pciaddr)
-
    if conf.vmdq then
       if devices[conf.pciaddr] == nil then
          devices[conf.pciaddr] = {pf=intel10g.new_pf(conf.pciaddr):open(), vflist={}}

--- a/src/doc/genbook.sh
+++ b/src/doc/genbook.sh
@@ -51,6 +51,10 @@ $(cat ../apps/socket/README.md)
 
 # Libraries
 
+## Hardware
+
+$(cat ../lib/hardware/README.md)
+
 ## Protocols
 
 $(cat ../lib/protocol/README.md)

--- a/src/lib/hardware/README.md
+++ b/src/lib/hardware/README.md
@@ -1,0 +1,183 @@
+### PCI (lib.hardware.pci)
+
+The `lib.hardware.pci` module provides functions that abstract common
+operations on PCI devices on Linux. In order to drive a PCI device using
+[Direct memory access (DMA)](https://en.wikipedia.org/wiki/Direct_memory_access)
+one must:
+
+1. Unbind the PCI device using `pci.unbind_device_from_linux`.
+2. Enable PCI bus mastering for device using `pci.set_bus_master` in
+   order to enable DMA.
+3. Memory map PCI device configuration space using `pci.map_pci_memory`.
+4. Control the PCI device by manipulating the memory referenced by the
+   pointer returned by `pci.map_pci_memory`.
+5. Disable PCI bus master for device using `pci.set_bus_master`.
+6. Unmap PCI device configuration space using `pci.close_pci_resource`.
+
+The correct ordering of these steps is absolutely critical.
+
+
+— Variable **pci.devices**
+
+An array of supported hardware devices. Must be populated by calling
+`pci.scan_devices`. Each entry is a table with the following keys:
+
+* `pciaddress`—String denoting the PCI address of the
+  device. E.g. `"0000:83:00.1"`.
+* `vendor`—Identification string e.g. `"0x8086"` for Intel.
+* `device`—Identification string e.g. `"0x10fb"` for 82599 chip.
+* `interface`—Name of Linux interface using this device e.g. `"eth0"`.
+* `status`—String denoting the Linux operational status, or `nil` if not
+  known.
+* `driver`—String denoting the Lua module that supports this hardware
+  e.g. `"apps.intel.intel10g"`.
+* `usable`—String denoting if the device was suitable to use when
+  scanned. One of `"yes"` or `"no"`.
+
+— Function **pci.scan_devices**
+
+Scans for available PCI devices and populates the `pci.devices` table.
+
+— Function **pci.unbind_device_from_linux** *pciaddress*
+
+Forces Linux to unbind the device identified by *pciaddress* from any
+kernel drivers.
+
+— Function **pci.set_bus_master** *pciaddress*, *enable*
+
+Enables or disables PCI bus mastering for device identified by
+*pciaddress* depending on whether *enable* is a true or a false
+value. PCI bus mastering must be enabled in order to perform DMA on the
+PCI device.
+
+— Function **pci.map_pci_memory** *pciaddress*, *n*
+
+Memory maps configuration space *n* of PCI device identified by
+*pciaddress*. Returns a pointer to the memory mapped region and a file
+descriptor of the opened sysfs resource file. PCI bus mastering must be
+enabled on device identified by *pciaddress* before calling his function.
+
+— Function **pci.close_pci_resource** *file_descriptor*, *pointer*
+
+Closes memory mapped *file_descriptor* of sysfs resource file and unmaps
+it from *pointer* as returned by `pci.map_pci_memory`.
+
+
+### Register (lib.hardware.register)
+
+The `lib.hardware.register` module provides an abstraction for hardware
+device registers. This abstraction can be used to declaratively specify
+and conveniently manipulate structured memory regions via DMA. The
+functions `register.define` and `register.define_array` construct
+`Register` objects based on a *register description* string. The
+resulting `Register` objects can be used to manipulate the defined
+registers using the methods `Register:read`, `Register:write`,
+`Register:set`, `Register:clr`, `Register:wait` and `Register:reset`
+(exact set depends on the *register mode*).
+
+A register description is a string with one `Register` object definition
+per line. A `Register` object definition must be expressed using the
+following grammar:
+
+```
+Register   ::= Name Offset Indexing Mode Longname
+Name       ::= <identifier>
+Indexing   ::= "-"
+           ::= "+" OffsetStep "*" Min ".." Max
+Mode       ::= "RO" | "RW" | "RC"
+Longname   ::= <string>
+Offset ::= OffsetStep ::= Min ::= Max ::= <number>
+```
+
+A `Register` object definition is made up of the following properties:
+
+* *Name*—A string to be used to refer to the `Register` object. Must
+  be a valid Lua identifier, e.g. `"foo"`, `"foo_bar"`, `"FOO"` etc.
+* *Offset*—Integer specifying the offset from the base pointer (as
+  supplied to `register.define` and `register.define_array`).
+* *Indexing*—Optional. Three integers specifying the offset step as well
+  as minimum and maximum indexes in bytes.
+* *Mode*—One of `"RO"`, `"RW"` or `"RC"` standing for *read-only*,
+  *read-write* and *counter* modes respectively. Counter mode is for
+  counter registers that clear back to zero when read.
+* *Longname*—A string describing the register (used for
+  self-documentation).
+
+For instance, the following `Register` object definition defines a
+register range "TXDCTL" in read-write mode starting at offset 0x06028
+with 128 registers each of length 0x40.
+
+```
+TXDCTL 0x06028 +0x40*0..127 RW Transmit Descriptor Control
+```
+
+The next example defines a singular register "TPT" in counter mode
+located at offset 0x01428.
+
+```
+TPT 0x01428 - RC Total Packets Transmitted
+```
+
+— Function **register.define** *description*, *table*, *base_pointer*,
+*n*
+
+Creates `Register` objects for *description* relative to
+*base_pointer*. The resulting `Register` objects will become a named
+entries in *table* using the names defined in *description*. If an entry
+in *description* defines an indexing range then *n* specifies the index
+of the register within that range. *N* defaults to 0.
+
+— Function **register.define_array** *description*, *table*,
+*base_pointer*
+
+Creates `Register` objects for *description* relative to
+*base_pointer*. The resulting `Register` objects will become a named
+entries in *table* using the names defined in *description*. If an entry
+in *description* defines an indexing range, an array of `Register`
+objects will be created instead of a singular `Register` object.
+
+— Function **register.dump** *table*
+
+Prints a pretty-printed register dump of a *table* of registers.
+
+— Method **Register:read**
+
+Returns the value of register. For convenience register objects can be
+called without arguments instead of calling
+`Register:read`. E.g. `reg:read()` is equivalent to `reg()`.
+
+— Method **Register:write** *value*
+
+Sets the value of register to *value*. Only available on registers in
+read-write mode. For convenience register objects can be called with an
+argument instead of calling `Register:write`. E.g. `reg:write(value)` is
+equivalent to `reg(value)`.
+
+If register is in counter mode it is assumed that the register will be
+reset to zero upon reading. The read value is added to a *register
+accumulator* and the sum of all reads is returned.
+
+— Method **Register:set** *bitmask*
+
+Sets bits of register according to *bitmask*. Only available on registers
+in read-write mode.
+
+— Method **Register:clr** *bitmask*
+
+Clears bits of register according to *bitmask*. Only available on
+registers in read-write mode.
+
+— Method **Register:wait**  *bitmask*, *value*
+
+Blocks until applying *bitmask* to the register equals *value*. If
+*value* is not supplied blocks until all bits in the mask are set
+instead. Only available on registers in read-write and read-only modes.
+
+— Method **Register:reset**
+
+Reset the register accumulator to 0. Only available on registers in
+counter mode.
+
+— Method **Register:print**
+
+Prints the register state to standard output.

--- a/src/lib/hardware/README.md.src
+++ b/src/lib/hardware/README.md.src
@@ -1,0 +1,183 @@
+### PCI (lib.hardware.pci)
+
+The `lib.hardware.pci` module provides functions that abstract common
+operations on PCI devices on Linux. In order to drive a PCI device using
+[Direct memory access (DMA)](https://en.wikipedia.org/wiki/Direct_memory_access)
+one must:
+
+1. Unbind the PCI device using `pci.unbind_device_from_linux`.
+2. Enable PCI bus mastering for device using `pci.set_bus_master` in
+   order to enable DMA.
+3. Memory map PCI device configuration space using `pci.map_pci_memory`.
+4. Control the PCI device by manipulating the memory referenced by the
+   pointer returned by `pci.map_pci_memory`.
+5. Disable PCI bus master for device using `pci.set_bus_master`.
+6. Unmap PCI device configuration space using `pci.close_pci_resource`.
+
+The correct ordering of these steps is absolutely critical.
+
+
+— Variable **pci.devices**
+
+An array of supported hardware devices. Must be populated by calling
+`pci.scan_devices`. Each entry is a table with the following keys:
+
+* `pciaddress`—String denoting the PCI address of the
+  device. E.g. `"0000:83:00.1"`.
+* `vendor`—Identification string e.g. `"0x8086"` for Intel.
+* `device`—Identification string e.g. `"0x10fb"` for 82599 chip.
+* `interface`—Name of Linux interface using this device e.g. `"eth0"`.
+* `status`—String denoting the Linux operational status, or `nil` if not
+  known.
+* `driver`—String denoting the Lua module that supports this hardware
+  e.g. `"apps.intel.intel10g"`.
+* `usable`—String denoting if the device was suitable to use when
+  scanned. One of `"yes"` or `"no"`.
+
+— Function **pci.scan_devices**
+
+Scans for available PCI devices and populates the `pci.devices` table.
+
+— Function **pci.unbind_device_from_linux** *pciaddress*
+
+Forces Linux to unbind the device identified by *pciaddress* from any
+kernel drivers.
+
+— Function **pci.set_bus_master** *pciaddress*, *enable*
+
+Enables or disables PCI bus mastering for device identified by
+*pciaddress* depending on whether *enable* is a true or a false
+value. PCI bus mastering must be enabled in order to perform DMA on the
+PCI device.
+
+— Function **pci.map_pci_memory** *pciaddress*, *n*
+
+Memory maps configuration space *n* of PCI device identified by
+*pciaddress*. Returns a pointer to the memory mapped region and a file
+descriptor of the opened sysfs resource file. PCI bus mastering must be
+enabled on device identified by *pciaddress* before calling his function.
+
+— Function **pci.close_pci_resource** *file_descriptor*, *pointer*
+
+Closes memory mapped *file_descriptor* of sysfs resource file and unmaps
+it from *pointer* as returned by `pci.map_pci_memory`.
+
+
+### Register (lib.hardware.register)
+
+The `lib.hardware.register` module provides an abstraction for hardware
+device registers. This abstraction can be used to declaratively specify
+and conveniently manipulate structured memory regions via DMA. The
+functions `register.define` and `register.define_array` construct
+`Register` objects based on a *register description* string. The
+resulting `Register` objects can be used to manipulate the defined
+registers using the methods `Register:read`, `Register:write`,
+`Register:set`, `Register:clr`, `Register:wait` and `Register:reset`
+(exact set depends on the *register mode*).
+
+A register description is a string with one `Register` object definition
+per line. A `Register` object definition must be expressed using the
+following grammar:
+
+```
+Register   ::= Name Offset Indexing Mode Longname
+Name       ::= <identifier>
+Indexing   ::= "-"
+           ::= "+" OffsetStep "*" Min ".." Max
+Mode       ::= "RO" | "RW" | "RC"
+Longname   ::= <string>
+Offset ::= OffsetStep ::= Min ::= Max ::= <number>
+```
+
+A `Register` object definition is made up of the following properties:
+
+* *Name*—A string to be used to refer to the `Register` object. Must
+  be a valid Lua identifier, e.g. `"foo"`, `"foo_bar"`, `"FOO"` etc.
+* *Offset*—Integer specifying the offset from the base pointer (as
+  supplied to `register.define` and `register.define_array`).
+* *Indexing*—Optional. Three integers specifying the offset step as well
+  as minimum and maximum indexes in bytes.
+* *Mode*—One of `"RO"`, `"RW"` or `"RC"` standing for *read-only*,
+  *read-write* and *counter* modes respectively. Counter mode is for
+  counter registers that clear back to zero when read.
+* *Longname*—A string describing the register (used for
+  self-documentation).
+
+For instance, the following `Register` object definition defines a
+register range "TXDCTL" in read-write mode starting at offset 0x06028
+with 128 registers each of length 0x40.
+
+```
+TXDCTL 0x06028 +0x40*0..127 RW Transmit Descriptor Control
+```
+
+The next example defines a singular register "TPT" in counter mode
+located at offset 0x01428.
+
+```
+TPT 0x01428 - RC Total Packets Transmitted
+```
+
+— Function **register.define** *description*, *table*, *base_pointer*,
+*n*
+
+Creates `Register` objects for *description* relative to
+*base_pointer*. The resulting `Register` objects will become a named
+entries in *table* using the names defined in *description*. If an entry
+in *description* defines an indexing range then *n* specifies the index
+of the register within that range. *N* defaults to 0.
+
+— Function **register.define_array** *description*, *table*,
+*base_pointer*
+
+Creates `Register` objects for *description* relative to
+*base_pointer*. The resulting `Register` objects will become a named
+entries in *table* using the names defined in *description*. If an entry
+in *description* defines an indexing range, an array of `Register`
+objects will be created instead of a singular `Register` object.
+
+— Function **register.dump** *table*
+
+Prints a pretty-printed register dump of a *table* of registers.
+
+— Method **Register:read**
+
+Returns the value of register. For convenience register objects can be
+called without arguments instead of calling
+`Register:read`. E.g. `reg:read()` is equivalent to `reg()`.
+
+— Method **Register:write** *value*
+
+Sets the value of register to *value*. Only available on registers in
+read-write mode. For convenience register objects can be called with an
+argument instead of calling `Register:write`. E.g. `reg:write(value)` is
+equivalent to `reg(value)`.
+
+If register is in counter mode it is assumed that the register will be
+reset to zero upon reading. The read value is added to a *register
+accumulator* and the sum of all reads is returned.
+
+— Method **Register:set** *bitmask*
+
+Sets bits of register according to *bitmask*. Only available on registers
+in read-write mode.
+
+— Method **Register:clr** *bitmask*
+
+Clears bits of register according to *bitmask*. Only available on
+registers in read-write mode.
+
+— Method **Register:wait**  *bitmask*, *value*
+
+Blocks until applying *bitmask* to the register equals *value*. If
+*value* is not supplied blocks until all bits in the mask are set
+instead. Only available on registers in read-write and read-only modes.
+
+— Method **Register:reset**
+
+Reset the register accumulator to 0. Only available on registers in
+counter mode.
+
+— Method **Register:print**
+
+Prints the register state to standard output.

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -91,7 +91,6 @@ function map_pci_memory (device, n)
 end
 
 -- Close a file descriptor opened by map_pci_memory().
--- XXX should also unmap the memory.
 function close_pci_resource (fd, base)
    C.close_pci_resource(fd, base)
 end

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -134,25 +134,3 @@ function print_device_summary ()
       print(fmt:format(unpack(values)))
    end
 end
-
-function open_usable_devices (options)
-   local drivers = {}
-   for _,device in ipairs(devices) do
-      if #drivers == 0 then
-         if device.usable == 'yes' then
-            if device.interface ~= nil then
-               print("Unbinding device from linux: "..device.pciaddress)
-               unbind_device_from_linux(device.pciaddress)
-            end
-            print("Opening device "..device.pciaddress)
-            local driver = open_device(device.pciaddress, device.driver)
-            driver:open_for_loopback_test()
-            table.insert(drivers, driver)
-         end
-      end
-   end
-   local options = {devices=drivers,
-                    program=port.Port.loopback_test,
-                    report=true}
-   port.selftest(options)
-end

--- a/src/lib/hardware/register.lua
+++ b/src/lib/hardware/register.lua
@@ -131,7 +131,7 @@ end
 --- The register objects become named entries in `table`.
 ---
 --- This is an example line for a register description:
----     TXDCTL    0x06028 +0x40*0..127 (RW) Transmit Descriptor Control
+---     TXDCTL    0x06028 +0x40*0..127 RW Transmit Descriptor Control
 ---
 --- and this is the grammar:
 ---     Register   ::= Name Offset Indexing Mode Longname

--- a/src/lib/hardware/register.lua
+++ b/src/lib/hardware/register.lua
@@ -51,6 +51,18 @@ function Register:reset () self.acc = 0 end
 --- For other registers provide a noop
 function Register:noop () end
 
+--- Print a standard register
+function Register:print ()
+   io.write(("%40s %s\n"):format(self, self.longname))
+end
+
+--- Print a counter register unless its accumulator value is 0.
+function Register:printrc ()
+   if self() > 0 then
+      io.write(("%40s (%16s) %s\n"):format(self, lib.comma_value(self()), self.longname))
+   end
+end
+
 --- Register objects are "callable" as functions for convenience:
 ---     reg()      <=> reg:read()
 ---     reg(value) <=> reg:write(value)
@@ -65,12 +77,15 @@ end
 
 --- Metatables for the three different types of register
 local mt = {
-  RO = {__index = { read=Register.read, wait=Register.wait, reset=Register.noop},
+  RO = {__index = { read=Register.read, wait=Register.wait,
+                    reset=Register.noop, print=Register.print},
         __call = Register.read, __tostring = Register.__tostring},
   RW = {__index = { read=Register.read, write=Register.write, wait=Register.wait,
-                    set=Register.set, clr=Register.clr, reset=Register.noop},
+                    set=Register.set, clr=Register.clr, reset=Register.noop,
+                    print=Register.print},
         __call = Register.__call, __tostring = Register.__tostring},
-  RC = {__index = { read=Register.readrc, reset=Register.reset},
+  RC = {__index = { read=Register.readrc, reset=Register.reset,
+                    print=Register.printrc},
         __call = Register.readrc, __tostring = Register.__tostring},
 }
 
@@ -180,24 +195,20 @@ end
 
 
 -- Print a pretty-printed register dump for a table of register objects.
-function dump (tab, iscounters)
+function dump (tab)
 --   print "Register dump:"
    local strings = {}
    for _,reg in pairs(tab) do
-      if type(reg)=='table' and (iscounters == nil or is_array(reg) or reg() > 0) then
+      if type(reg)=='table' then
          table.insert(strings, reg)
       end
    end
    table.sort(strings, function(a,b) return a.name < b.name end)
    for _,reg in ipairs(strings) do
       if is_array(reg) then
-         dump(reg, iscounters)
+         dump(reg)
       else
-         if iscounters then
-            io.write(("%40s %16s %s\n"):format(reg.name, lib.comma_value(reg()), reg.longname))
-         else
-            io.write(("%40s %s\n"):format(reg, reg.longname))
-         end
+         reg:print()
       end
    end
 end


### PR DESCRIPTION
1. Polishes the code at `lib/hardware` a bit and adds proper documentation.
2. Fix more or less critical bugs related to `lib.hardware.pci` usage.