### PR TITLE
snabbnfv traffic: Add missing 'require' that broke program

### DIFF
--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -3,6 +3,8 @@ module(..., package.seeall)
 local lib = require("core.lib")
 local nfvconfig = require("program.snabbnfv.nfvconfig")
 local usage = require("program.snabbnfv.traffic.README_inc")
+local ffi = require("ffi")
+local C = ffi.C
 
 local long_opts = {
    benchmark = "B"


### PR DESCRIPTION
The command `snabbnfv traffic` is broken without this fix.