### PR TITLE
Remove garbage from core.apps.restart_dead_apps()

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -51,10 +51,13 @@ local function with_restart (app, method)
 end
 
 -- Restart dead apps.
+local actions = { start={}, restart={}, reconfig={}, keep={}, stop={} }
 function restart_dead_apps ()
+   if not use_restart then return end
    local restart_delay = 2 -- seconds
-   local actions = { start={}, restart={}, reconfig={}, keep={}, stop={} }
    local restart = false
+   actions.restart[1] = nil
+   actions.keep[1] = nil
 
    -- Collect 'restart' actions for dead apps and log their errors.
    for i = 1, #app_array do


### PR DESCRIPTION
The "action" table is allocated each time the function is called,
which creates a fair amount of garbage, even if the restart mechanism
isn't actually used, which is the default.

This commit includes a bypass of the function if use_restart is false.
If use_restart is true, the action table is allocated statically and
only the sub-tables that are used by the function are cleared.

The dead-app detection code probably contains more of this kind of
garbage, e.g. in the apply_config_action() function.