### PR TITLE
Makefile: Streamline LuaJIT build options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ COBJ   = $(CSRC:.c=.o)
 LUAJIT_O := deps/luajit/src/libluajit.a
 SYSCALL  := src/syscall.lua
 
-LUAJIT_CFLAGS := -DLUAJIT_USE_PERFTOOLS -DLUAJIT_USE_GDBJIT -DLUAJIT_NUMMODE=3 -include $(CURDIR)/gcc-preinclude.h
+LUAJIT_CFLAGS := -include $(CURDIR)/gcc-preinclude.h
 
 all: $(LUAJIT_O) $(SYSCALL)
 	@echo "Building snabbswitch"


### PR DESCRIPTION
Strip away these options:

    -DLUAJIT_USE_PERFTOOLS

This feature causes noise in /tmp (perf-nnnn.map files). There is a
better way to profile at trace granularity with the LuaJIT
profiler. Hopefully this will be upstream in LuaJIT but for now
available as a patch:
http://www.freelists.org/post/luajit/Profile-at-trace-granularity,1

    -DLUAJIT_USE_GDBJIT

The documentation says that "enabling it always has a non-negligible
overhead -- do not use in release mode" and I don't believe that we
are using this functionality (debugging JIT traces in gdb).

    -DLUAJIT_NUMMODE=3

This is less clear cut. Mike Pall has encouraged us to experiment with
settings for this variable for potential performance benefits. The
current value (3) was chosen during a micro-optimization spree many
moons ago. I am not confident whether this setting helps or is better
than other settings. So I am disabling it in this commit ("less
voodoo") and we will have to check for performance regressions before
merging onto master.