### PR TITLE
More logging bench_env

### DIFF
--- a/src/scripts/bench_env/common.sh
+++ b/src/scripts/bench_env/common.sh
@@ -31,7 +31,7 @@ run_qemu () {
             -M pc -smp $SMP -cpu host --enable-kvm \
             -serial telnet:localhost:$TELNETPORT,server,nowait \
             -drive if=virtio,file=$IMG \
-            -nographic > /dev/null 2>&1 &
+            -nographic > /tmp/bench-env-qemu.${TELNETPORT} 2>&1 &
     QEMUPIDS="$QEMUPIDS $!"
 }
 

--- a/src/scripts/bench_env/host-nic-snabbnfv-guests.sh
+++ b/src/scripts/bench_env/host-nic-snabbnfv-guests.sh
@@ -20,7 +20,7 @@ GUESTS="2"
 export NFV_PCI=${NFV_PCI0?}
 numactl --cpunodebind=${NODE_BIND0?} --membind=${NODE_BIND0?} \
     $SNABB snabbnfv traffic ${NFV_PCI0?} ${1?} vhost_%s.sock \
-    > ${SNABB_LOG0?} 2>&1 &
+    > /tmp/bench-env-traffic.${NFV_PCI0?} 2>&1 &
 SNABB_PID0=$!
 
 # Execute QEMU on the same node


### PR DESCRIPTION
Log the output of QEMU and snabbnfv traffic to files in `/tmp/`.

This is intended partly to help debug SnabbBot test failures.