### PR TITLE
Various SnabbBot, cperf, snabbnfv selftest and bench_env updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,7 @@ Use the
 mailing list for general technical discussions. Submit code with
 Github pull requests. Report bugs with Github issues.
 
+
+### Benchmark Results
+
+[![Benchmark Results](http://lab1.snabb.co:2008/~max/benchmarks.png)](https://travis-ci.org/SnabbCo/snabbswitch.svg?branch=master)

--- a/src/program/snabbnfv/selftest.sh
+++ b/src/program/snabbnfv/selftest.sh
@@ -29,6 +29,7 @@ fi
 export BENCH_ENV_PID
 
 TESTCONFPATH="/tmp/snabb_nfv_selftest_ports.$$"
+FUZZCONFPATH="/tmp/snabb_nfv_selftest_fuzz$$.ports"
 
 # Usage: run_telnet <port> <command> [<sleep>]
 # Runs <command> on VM listening on telnet <port>. Waits <sleep> seconds
@@ -284,8 +285,8 @@ function fuzz_tests {
     for ((n=0;n<$1;n++)); do
         $SNABB snabbnfv fuzz \
             program/snabbnfv/test_fixtures/nfvconfig/fuzz/filter2-tunnel-txrate10-ports.spec \
-            /tmp/snabb_nfv_selftest_fuzz.ports
-        load_config /tmp/snabb_nfv_selftest_fuzz.ports
+            $FUZZCONFPATH
+        load_config $FUZZCONFPATH
         test_iperf $TELNET_PORT0 $TELNET_PORT1 "$GUEST_IP1%eth0"
     done
 }

--- a/src/program/snabbnfv/selftest.sh
+++ b/src/program/snabbnfv/selftest.sh
@@ -102,8 +102,20 @@ function wait_vm_up {
 
 function assert {
     if [ $2 == "0" ]; then echo "$1 succeded."
-    else echo "$1 failed."
-         exit 1
+    else
+        echo "$1 failed."
+        echo
+        echo "qemu ($IMAGE0) log:"
+        cat "$(basename "$IMAGE0").log"
+        echo
+        echo
+        echo "qemu ($IMAGE1) log:"
+        cat "$(basename "$IMAGE1").log"
+        echo
+        echo
+        echo "snabbnfv log:"
+        cat "$SNABB_LOG0"
+        exit 1
     fi
 }
 

--- a/src/scripts/bench_env/common.sh
+++ b/src/scripts/bench_env/common.sh
@@ -31,7 +31,7 @@ run_qemu () {
             -M pc -smp $SMP -cpu host --enable-kvm \
             -serial telnet:localhost:$TELNETPORT,server,nowait \
             -drive if=virtio,file=$IMG \
-            -nographic > /dev/null 2>&1 &
+        -nographic > "$(basename "${IMG?}").log" 2>&1 &
     QEMUPIDS="$QEMUPIDS $!"
 }
 

--- a/src/scripts/cperf/benchmarks/basic1-10e6
+++ b/src/scripts/cperf/benchmarks/basic1-10e6
@@ -12,7 +12,7 @@
 set -e
 
 # The actual benchmark.
-out=$(sudo src/snabb src/designs/bench/basic1 10e6)
+out=$(sudo src/snabb snabbmark basic1 10e6)
 
 # Extract floating point Mpps number from output.
 echo "$out" | tail -n 1 | cut -d " " -f 9

--- a/src/scripts/cperf/benchmarks/iperf-jumbo
+++ b/src/scripts/cperf/benchmarks/iperf-jumbo
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# There is a reason for this Shell script being so weird
+# (by using `set -e' and `echo $out | ...'):
+#
+# If a benchmark script fails it MUST exit with a non-zero status. Thus
+# we make sure that the status returned reflects the benchmarks results
+# and NOT the commands that extract the desired portion of the benchmarks
+# output. (Last time I checked, even with `set -e ', a plain pipe will
+# exit with status 0 even if one of the commands does not).
+
+set -e
+
+# The actual benchmark.
+out=$(cd src; sudo program/snabbnfv/selftest.sh bench)
+
+# Extract floating point Gbits number from output.
+echo "$out" | grep IPERF-JUMBO | cut -d " " -f 2

--- a/src/scripts/cperf/cperf.sh
+++ b/src/scripts/cperf/cperf.sh
@@ -79,7 +79,7 @@ set terminal png size 1600,800
 set output "$2"
 set offset graph 0.02, 0.2, 0.02, 0.02
 #set yrange [0:50]
-set ylabel "Mpps (mean of $SAMPLESIZE runs with standard deviation)"
+set ylabel "Score (mean of $SAMPLESIZE runs with standard deviation)"
 set xlabel "Git ref (abbreviated)"
 plot $(compile_plot_args "$1")
 EOF

--- a/src/scripts/cperf/cperf.sh
+++ b/src/scripts/cperf/cperf.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-# Usage: cperf.sh plot <commit-range>
+# Usage: cperf.sh plot [<commit-range>]
 #        cperf.sh check <sha-x> <sha-y>
 #
 # In `plot' mode: Runs benchmarks for each merge commit in that range and
 # records their results unless a record for that run already exists and
-# plots the resulting records.
+# plots the resulting records. If commit-range is omitted the already
+# persisted results are plotted instead.
 #
 # In `check' mode: Compares benchmark results of commits <sha-x> and
 # <sha-y> and prints the results. Runs benchmarks for commits unless a
@@ -132,11 +133,21 @@ function plot_records {
     rm -rf $graph_tmp
 }
 
-# Plot mode: Plot benchmarking results for commit range `$1'.
+# Plot mode: Plot benchmarking results for commit range `$1'. If `$1' is
+# omitted create plot for persisted results.
 function plot_mode {
 
-    # Get commits in <commit-range> ($1).
-    commits="$(git log --format=format:%H --merges --reverse "$1")"
+    if [ "$1" != "" ]; then
+
+        # Get commits in <commit-range> ($1).
+        commits="$(git log --format=format:%H --merges --reverse "$1")"
+
+    else
+
+        # Just use persisted results.
+        commits="$(ls "$graph_data/")"
+
+    fi
 
     # Run benchmarks and record their results in `graph_data'.
     for benchmark in "$benchmarks"/*; do

--- a/src/scripts/snabb_bot/tasks/test.sh
+++ b/src/scripts/snabb_bot/tasks/test.sh
@@ -3,18 +3,31 @@
 # Run tests. 
 
 cd src/
-test_out=$(sudo make test 2>&1)
+test_out=$(sudo \
+    SNABB_TEST_INTEL10G_PCIDEVA=0000:86:00.0 \
+    SNABB_TEST_INTEL10G_PCIDEVB=0000:86:00.1 \
+    flock -x /tmp/86:00.lock \
+    make test 2>&1)
 
-sudo rm -rf testlog/
+EXIT=1
 
 if echo "$test_out" | grep ERROR > /dev/null; then
     echo "Tests failed. See test output below:"
     echo
     echo "$test_out"
-    exit 1
 else
     echo "Tests successful."
     echo
     echo "$test_out"
-    exit 0
+    EXIT=0
 fi
+
+echo
+for log in testlog/*; do
+    echo "BEGIN $log"
+    cat "$log"
+    echo
+done
+
+sudo rm -rf testlog/
+exit $EXIT


### PR DESCRIPTION
This branch adds a new `iperf-jumbo` benchmark based on the snabbnfv selftest, increases snabbnfv selftest verbosity, updates `cperf.sh check` to persist results and includes other minor improvements.