### PR TITLE
neutron_sync_master.sh: remove DB tables no longer used

### DIFF
--- a/src/program/snabbnfv/neutron_sync_master/neutron_sync_master.sh
+++ b/src/program/snabbnfv/neutron_sync_master/neutron_sync_master.sh
@@ -19,7 +19,7 @@ function check_env_vars()
     [ ! -z "$DB_NEUTRON" ] || export DB_NEUTRON=neutron_ml2
     [ ! -z "$DB_NEUTRON_TABLES" ] || export DB_NEUTRON_TABLES="networks \
         ports ml2_network_segments securitygroups securitygrouprules \
-        securitygroupportbindings qos_policies qoses portqosmappings"
+        securitygroupportbindings"
     [ ! -z "$SYNC_LISTEN_HOST" ] || export SYNC_LISTEN_HOST=127.0.0.1
     [ ! -z "$SYNC_LISTEN_PORT" ] || export SYNC_LISTEN_PORT=9418
     [ ! -z "$SYNC_INTERVAL" ] || export SYNC_INTERVAL=1


### PR DESCRIPTION
The default value for DB_NEUTRON_TABLES variable contains: "qos_policies qoses portqosmappings" which is not used anymore by the neutron2snabb program.