### PR TITLE
[csum-offload-simd] Incoming checksum verification

### DIFF
--- a/src/lib/checksum.c
+++ b/src/lib/checksum.c
@@ -325,8 +325,7 @@ uint32_t pseudo_header_initial(const int8_t *buf, size_t len)
               + hwbuf[9];
 
     } else {                                // IPv6
-      sum = htons((len & 0xFFFF0000) >> 16) + htons(len & 0x0000FFFF) + (proto << 8);
-      sum += hwbuf[2] + (proto << 8);
+      sum = hwbuf[2] + (proto << 8);
       int i;
       for (i = 4; i < 20; i+=4) {
         sum += hwbuf[i] +
@@ -337,7 +336,10 @@ uint32_t pseudo_header_initial(const int8_t *buf, size_t len)
     }
     sum = ((sum & 0xffff0000) >> 16) + (sum & 0xffff);
     sum = ((sum & 0xffff0000) >> 16) + (sum & 0xffff);
-    return ntohs(sum);
+	if (len >= 128) {
+		sum = ntohs(sum);
+	}
+    return sum; // ntohs(sum);
   }
   return 0;
 }

--- a/src/lib/checksum.c
+++ b/src/lib/checksum.c
@@ -135,7 +135,7 @@ static inline uint32_t cksum_sse2_loop(unsigned char *p, size_t n)
 
 uint16_t cksum_sse2(unsigned char *p, size_t n, uint32_t initial)
 {
-  uint32_t sum = initial;
+  uint32_t sum = ntohs(initial);
 
   if (n < 128) { return cksum_generic(p, n, initial); }
   int unaligned = (unsigned long) p & 0xf;
@@ -217,7 +217,7 @@ static inline uint32_t cksum_avx2_loop(unsigned char *p, size_t n)
 
 uint16_t cksum_avx2(unsigned char *p, size_t n, uint32_t initial)
 {
-    uint32_t sum = initial;
+    uint32_t sum = ntohs(initial);
 
     if (n < 128) { return cksum_generic(p, n, initial); }
     int unaligned = (unsigned long) p & 31;
@@ -297,7 +297,7 @@ uint32_t tcp_pseudo_checksum(uint16_t *sip, uint16_t *dip,
 // calculates the initial checksum value resulting from
 // the pseudo header.
 // return values:
-// 0x0000 - 0xFFFF : initial checksum.
+// 0x0000 - 0xFFFF : initial checksum (in network order).
 // 0xFFFF0001 : unknown packet (non IPv4/6 or non TCP/UDP)
 // 0xFFFF0002 : bad header
 uint32_t pseudo_header_initial(const int8_t *buf, size_t len)
@@ -342,10 +342,7 @@ uint32_t pseudo_header_initial(const int8_t *buf, size_t len)
     }
     sum = ((sum & 0xffff0000) >> 16) + (sum & 0xffff);
     sum = ((sum & 0xffff0000) >> 16) + (sum & 0xffff);
-	if (len >= 128) {
-		sum = ntohs(sum);
-	}
-    return sum; // ntohs(sum);
+    return sum;
   }
   return 0xFFFF0001;
 }

--- a/src/lib/checksum.h
+++ b/src/lib/checksum.h
@@ -23,3 +23,9 @@ void checksum_update_incremental_32(uint16_t* checksum_cell,
 uint32_t tcp_pseudo_checksum(uint16_t *sip, uint16_t *dip,
                              int addr_halfwords, int len);
 
+typedef struct {
+  uint32_t initial;
+  int headersize;
+} pseudoheader;
+
+pseudoheader pseudo_header_initial(const int8_t *buf, size_t len);

--- a/src/lib/checksum.h
+++ b/src/lib/checksum.h
@@ -23,9 +23,4 @@ void checksum_update_incremental_32(uint16_t* checksum_cell,
 uint32_t tcp_pseudo_checksum(uint16_t *sip, uint16_t *dip,
                              int addr_halfwords, int len);
 
-typedef struct {
-  uint32_t initial;
-  int headersize;
-} pseudoheader;
-
-pseudoheader pseudo_header_initial(const int8_t *buf, size_t len);
+uint32_t pseudo_header_initial(const int8_t *buf, size_t len);

--- a/src/lib/checksum.lua
+++ b/src/lib/checksum.lua
@@ -27,6 +27,12 @@ function finish_packet (buf, len, offset)
    ffi.cast('uint16_t *', buf+offset)[0] = lib.htons(ipsum(buf, len, 0))
 end
 
+function verify_packet (buf, len)
+   local phead = C.pseudo_header_initial(buf, len)
+   if phead.initial == 0 then return false end
+
+   return ipsum(buf+phead.headersize, len-phead.headersize, phead.initial) == 0
+end
 
 -- See checksum.h for more utility functions that can be added.
 

--- a/src/lib/checksum.lua
+++ b/src/lib/checksum.lua
@@ -55,14 +55,15 @@ function selftest ()
    for i = 0, n-1 do  array[i] = i  end
    local avx2ok, sse2ok = 0, 0
    for i = 1, tests do
-      local ref =   C.cksum_generic(array+i*2, i*10+i, 0)
-      if have_avx2 and C.cksum_avx2(array+i*2, i*10+i, 0) == ref then
-	 avx2ok = avx2ok + 1
+      local initial = math.random(0, 0xFFFF)
+      local ref =   C.cksum_generic(array+i*2, i*10+i, initial)
+      if have_avx2 and C.cksum_avx2(array+i*2, i*10+i, initial) == ref then
+         avx2ok = avx2ok + 1
       end
-      if have_sse2 and C.cksum_sse2(array+i*2, i*10+i, 0) == ref then
-	 sse2ok = sse2ok + 1
+      if have_sse2 and C.cksum_sse2(array+i*2, i*10+i, initial) == ref then
+         sse2ok = sse2ok + 1
       end
-      assert(ipsum(array+i*2, i*10+i, 0) == ref, "API function check")
+      assert(ipsum(array+i*2, i*10+i, initial) == ref, "API function check")
    end
    if have_avx2 then print("avx2: "..avx2ok.."/"..tests) else print("no avx2") end
    if have_sse2 then print("sse2: "..sse2ok.."/"..tests) else print("no sse2") end

--- a/src/lib/checksum.lua
+++ b/src/lib/checksum.lua
@@ -30,7 +30,9 @@ end
 
 function verify_packet (buf, len)
    local initial = C.pseudo_header_initial(buf, len)
-   if initial == 0 then return false end
+   if     initial == 0xFFFF0001 then return nil
+   elseif initial == 0xFFFF0002 then return false
+   end
 
    local headersize = 0
    local ipv = band(buf[0], 0xF0)


### PR DESCRIPTION
Checks incoming packets, works for both IPv4 and IPv6, TCP and UDP.

Performance seems terrible, I guess because of all the `ntohs()` calls.  I'm sure there's some way to factor them out, probably involving a little bit-shuffling.