### PR TITLE
Run in busy-loop (engine.Hz = false) by default

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -26,7 +26,7 @@ configuration = config.new()
 -- Count of the number of breaths taken
 breaths = 0
 -- Ideal number of breaths per second
-Hz = 10000
+Hz = false
 
 -- Return current monotonic time in seconds.
 -- Can be used to drive timers in apps.


### PR DESCRIPTION
This will make Snabb Switch always show 100% CPU in default settings.

Previously Snabb Switch has by default attempted to bring in a batch
of new packets once every 100us. This is too conservative on the
straightline design because we now work on smaller batches of
packets (max is now 256 and was 8192 before). So this change makes the
default behavior to busy-loop without sleeping to maximize throughput.

Going forwards we should consider a dynamic mechanism that will make a
truly idle Snabb Switch sleep. Meanwhile the default is to busy-loop
and a static configuration is possible with a setting like
'engine.Hz=10000'.