### PR TITLE
engine: Make link report prettier

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -268,10 +268,15 @@ function report (options)
       return tonumber(drop) * 100 / (tonumber(drop)+sent)
    end
    if not options or options.showlinks then
-      print("link report")
-      for name, l in pairs(link_table) do
-         print(("%s sent on %s (loss rate: %d%%))"):format(l.stats.txpackets,
-            name, loss_rate(l.stats.txdrop, l.stats.txpackets)))
+      print("link report:")
+      local names = {}
+      for name in pairs(link_table) do table.insert(names, name) end
+      table.sort(names)
+      for i, name in ipairs(names) do
+	 l = link_table[name]
+         print(("%20s sent on %s (loss rate: %d%%)"):format(
+		  lib.comma_value(l.stats.txpackets),
+		  name, loss_rate(l.stats.txdrop, l.stats.txpackets)))
       end
    end
    if options and options.showapps then


### PR DESCRIPTION
The standard link report printout is now a little prettier:

* Links are alphabetically sorted (resolves #385).
* Punctuation is improved.
* Values are printed with commas and justified.

Before:

    link report
    597223954 sent on Virtio_A.tx -> NIC_A.rx (loss rate: 0%))
    137411842 sent on NIC_A.tx -> Virtio_A.rx (loss rate: 0%))
    597223786 sent on NIC_B.tx -> Virtio_B.rx (loss rate: 0%))
    137411851 sent on Virtio_B.tx -> NIC_B.rx (loss rate: 0%))

After:

    link report:
	      17,747,602 sent on NIC_A.tx -> Virtio_A.rx (loss rate: 0%)
	      70,955,552 sent on NIC_B.tx -> Virtio_B.rx (loss rate: 0%)
	      70,955,729 sent on Virtio_A.tx -> NIC_A.rx (loss rate: 0%)
	      17,747,621 sent on Virtio_B.tx -> NIC_B.rx (loss rate: 0%)