### PR TITLE
Relax requirement to run as root and `mlock()` less memory

### DIFF
--- a/src/core/clib.h
+++ b/src/core/clib.h
@@ -61,6 +61,3 @@ uint16_t ntohs(uint16_t);
 uint32_t htonl(uint32_t);
 uint32_t ntohl(uint32_t);
 
-// geteuid(2) - get effective user identity
-int geteuid();
-

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -3,6 +3,7 @@ module(...,package.seeall)
 local ffi = require("ffi")
 local C = ffi.C
 local getopt = require("lib.lua.alt_getopt")
+local syscall = require("syscall")
 require("core.clib_h")
 
 -- Returns true if x and y are structurally similar (isomorphic).
@@ -416,6 +417,14 @@ function have_module (name)
 	 end
       end
       return false
+   end
+end
+
+-- Exit with an error if we are not running as root.
+function root_check (message)
+   if syscall.geteuid() ~= 0 then
+      print(message or "error: must run as root")
+      main.exit(1)
    end
 end
 

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -81,10 +81,6 @@ function initialize ()
    require("core.lib")
    require("core.clib_h")
    require("core.lib_h")
-   if C.geteuid() ~= 0 then
-      print("error: snabb has to run as root.")
-      os.exit(1)
-   end
    -- Global API
    _G.config = require("core.config")
    _G.engine = require("core.app")

--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -116,12 +116,3 @@ function selftest (options)
    print("HugeTLB page allocation OK.")
 end
 
---- ### module init: `mlock()` at load time
-
---- This module requires a stable physical-virtual mapping so this is
---- enforced automatically at load-time.
-function module_init ()
-   assert(C.lock_memory() == 0)
-end
-
-module_init()

--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -61,6 +61,7 @@ function allocate_hugetlb_chunk ()
 end
 
 function reserve_new_page ()
+   lib.root_check("error: must run as root to allocate memory for DMA")
    set_hugepages(get_hugepages() + 1)
 end
 

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -100,7 +100,3 @@ function preallocate_step()
    packet_allocation_step = 2 * packet_allocation_step
 end
 
---preallocate packets freelist
-if freelist_nfree(packets_fl) == 0 then
-   preallocate_step()
-end

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -71,6 +71,7 @@ end
 --- Force Linux to release the device with `pciaddress`.
 --- The corresponding network interface (e.g. `eth0`) will disappear.
 function unbind_device_from_linux (pciaddress)
+   root_check()
     local p = path(pciaddress).."/driver/unbind"
     if lib.can_write(p) then
         lib.writefile(path(pciaddress).."/driver/unbind", pciaddress)
@@ -82,6 +83,7 @@ end
 --   Pointer for memory-mapped access.
 --   File descriptor for the open sysfs resource file.
 function map_pci_memory (device, n)
+   root_check()
    local filepath = path(device).."/resource"..n
    local fd = C.open_pci_resource(filepath)
    assert(fd >= 0)
@@ -98,6 +100,7 @@ end
 --- Enable or disable PCI bus mastering. DMA only works when bus
 --- mastering is enabled.
 function set_bus_master (device, enable)
+   root_check()
    local fd = C.open_pcie_config(path(device).."/config")
    local value = ffi.new("uint16_t[1]")
    assert(C.pread(fd, value, 2, 0x4) == 2)
@@ -108,6 +111,10 @@ function set_bus_master (device, enable)
    end
    assert(C.pwrite(fd, value, 2, 0x4) == 2)
    C.close(fd)
+end
+
+function root_check ()
+   lib.root_check("error: must run as root to access PCI devices")
 end
 
 --- ### Selftest


### PR DESCRIPTION
Allow Snabb Switch to run as a non-root user unless/until privileged operations are required e.g. access to hardware and DMA.

These privileged operations are deferred from startup:

* Locking memory. Previously we called `mlockall()` while loading the memory module, but now we call `mlock()` individually on the HugeTLBs we allocate for DMA.
* Allocating packets. Previously we populated the packet freelist with DMA memory while loading the packet module, but now we wait until the first packet is allocated.