### PR TITLE
snabbnfv: Improve --help usage printouts

### DIFF
--- a/src/program/snabbnfv/README
+++ b/src/program/snabbnfv/README
@@ -6,3 +6,5 @@ Usage:
   snabbnfv fuzz
 
 Use --help for per-command usage.
+Example: 
+    snabbnfv traffic --help

--- a/src/program/snabbnfv/neutron_sync_agent/README
+++ b/src/program/snabbnfv/neutron_sync_agent/README
@@ -1,1 +1,22 @@
-neutron-sync-agent
+snabbnfv neutron-sync-agent [OPTIONS]
+
+Poll the neutron-sync-master for new database configurations and
+translate them into snabbnfv traffic process configuration files.
+
+  -s DIR, --snabb-dir DIR
+                             Output snabbnfv traffic config files to DIR.
+                             Default: $SNABB_DIR
+  -h HOST, --sync-host HOST
+                             Connect to snabbnfv-sync-master on HOST.
+                             Default: $SYNC_HOST
+  -p PATH, --sync-path PATH
+                             Use PATH on snabbnfv-sync-master.
+                             Default: $SYNC_PATH
+  -d DIR, --neutron-dir DIR
+                             Store temporary Neutron database dumps in DIR.
+			     Default: $NEUTRON_DIR
+  -i SECONDS, --interval SECONDS
+                             Sleep for SECONDS between sync requests.
+                             Default: $SYNC_INTERVAL or 1
+  -h, --help
+                             Print this help message and exit.

--- a/src/program/snabbnfv/neutron_sync_master/README
+++ b/src/program/snabbnfv/neutron_sync_master/README
@@ -1,1 +1,25 @@
-snabbnfv neutron-sync-master 
+snabbnfv neutron-sync-master [OPTIONS]
+
+Poll the Neutron database for configuration updates and make these
+available to snabbnfv-sync-agent processes running on other hosts.
+
+  -u USER, --user USER
+                             MySQL username for Neutron DB.
+			     Default: $DB_USER
+  -p PASS, --password PASS
+                             MySQL password for Neutron DB.
+			     Default: $DB_PASSWORD
+  -D DB, --neutron-database DB
+                             MySQL database name for Neutron DB.
+                             Default: $DB_NEUTRON or "neutron_ml2"
+  -m HOST, --mysql-host HOST
+                             MySQL hostname.
+                             Default: $DB_HOST or "localhost"
+  -l ADDRESS, --listen-address ADDRESS
+                             Listen on ADDRESS for sync-agent connections.
+                             Default: $SYNC_LISTEN_HOST or "127.0.0.1"
+  -i SECONDS, --interval SECONDS
+                             Sleep for SECONDS between database snapshots.
+                             Default: $SYNC_INTERVAL or "1"  
+  -h, --help
+                             Print this help message and exit.

--- a/src/program/snabbnfv/traffic/README
+++ b/src/program/snabbnfv/traffic/README
@@ -2,37 +2,44 @@ snabbnfv traffic [OPTIONS] <pci-address> <config-file> <socket-path>
 
   -B NPACKETS, --benchmark NPACKETS
                              Benchmark processing NPACKETS.
+  -h, --help
+                             Print brief command-line usage information.
+  -H, --long-help
+                             Print long usage information including
+                             configuration file format.
 
 Process traffic between Neutron ports and a physical NIC.
 
 In benchmark mode, measure the throughput for the first <npackets> and
 then report and terminate.
 
-<config-file> lists all of the virtual machine ports. The file is in
-Lua source format and returns an array of ports:
+CONFIG FILE FORMAT:
 
-    return { <port-1>, ..., <port-n> }
+  <config-file> contains a list of all of the virtual machine ports. The
+  file is in Lua source format and returns an array of ports:
 
-Each port is defined by a range of properties which correspond to the
-configuration parameters of the underlying apps (Intel10G, VhostUser,
-PacketFilter, RateLimiter, nd_light and SimpleKeyedTunnel):
+      return { <port-1>, ..., <port-n> }
 
-    port := { port_id        = <id>,          -- A unique string
-	      mac_address    = <mac-address>, -- As for Intel10G
-	      vlan           = <vlan-id>,     -- ..
-	      ingress_filter = <rules>,       -- As for PacketFilter
-	      egress_filter  = <rules>,       -- ..
-	      tunnel         = <tunnel-conf>,
-	      rx_police_gbps = <n>,           -- Allowed input rate in Gbps
-	      tx_police_gbps = <n> }          -- Allowed output rate in Gbps
+  Each port is defined by a range of properties which correspond to the
+  configuration parameters of the underlying apps (Intel10G, VhostUser,
+  PacketFilter, RateLimiter, nd_light and SimpleKeyedTunnel):
 
-The tunnel section deviates a little from SimpleKeyedTunnel's
-terminology:
+      port := { port_id        = <id>,          -- A unique string
+		mac_address    = <mac-address>, -- As for Intel10G
+		vlan           = <vlan-id>,     -- ..
+		ingress_filter = <rules>,       -- As for PacketFilter
+		egress_filter  = <rules>,       -- ..
+		tunnel         = <tunnel-conf>,
+		rx_police_gbps = <n>,           -- Allowed input rate in Gbps
+		tx_police_gbps = <n> }          -- Allowed output rate in Gbps
 
-    tunnel := { type          = "L2TPv3",     -- The only type (for now)
-		local_cookie  = <cookie>,     -- As for SimpleKeyedTunnel
-		remote_cookie = <cookie>,     -- ..
-		next_hop      = <ip-address>, -- Gateway IP
-		local_ip      = <ip-address>, -- ~ `local_address'
-		remote_ip     = <ip-address>, -- ~ `remote_address'
-		session       = <32bit-int>   -- ~ `session_id' }
+  The tunnel section deviates a little from SimpleKeyedTunnel's
+  terminology:
+
+      tunnel := { type          = "L2TPv3",     -- The only type (for now)
+		  local_cookie  = <cookie>,     -- As for SimpleKeyedTunnel
+		  remote_cookie = <cookie>,     -- ..
+		  next_hop      = <ip-address>, -- Gateway IP
+		  local_ip      = <ip-address>, -- ~ `local_address'
+		  remote_ip     = <ip-address>, -- ~ `remote_address'
+		  session       = <32bit-int>   -- ~ `session_id' }

--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -7,14 +7,18 @@ local ffi = require("ffi")
 local C = ffi.C
 
 local long_opts = {
-   benchmark = "B"
+   benchmark     = "B",
+   help          = "h",
+   ["long-help"] = "H"
 }
 
 function run (args)
    local opt = {}
    local benchpackets
-   function opt.B (arg) benchpackets = tonumber(arg) end
-   lib.dogetopt(args, opt, "B:", long_opts)
+   function opt.B (arg) benchpackets = tonumber(arg)      end
+   function opt.h (arg) print(short_usage()) main.exit(1) end
+   function opt.H (arg) print(long_usage())  main.exit(1) end
+   lib.dogetopt(args, opt, "hHB:", long_opts)
    if #args == 3 then
       local pciaddr, confpath, sockpath = unpack(args)
       if benchpackets then
@@ -27,10 +31,13 @@ function run (args)
    else
       print("Wrong number of arguments: " .. tonumber(#args))
       print()
-      print(usage)
+      print(short_usage())
       main.exit(1)
    end
 end
+
+function short_usage () return (usage:gsub("%s*CONFIG FILE FORMAT:.*", "")) end
+function long_usage () return usage end
 
 -- Run in real traffic mode.
 function traffic (pciaddr, confpath, sockpath)


### PR DESCRIPTION
Added proper usage for `neutron-sync-master` and `neutron-sync-agent`.

Created separate usage commands for `traffic`: `-h/--help` prints command
line usage, `-H/--long-help` also prints the configuration file format.