### PR TITLE
[nfvconfig] Remove obsolete notion of "zerocopy pairs"

### DIFF
--- a/src/apps/vhost/vhost_user.lua
+++ b/src/apps/vhost/vhost_user.lua
@@ -58,8 +58,10 @@ function VhostUser:stop()
    self.connected = false
    self.vhost_ready = false
    -- close the socket
-   C.close(self.socket)
-   self.socket = -1
+   if self.socket then
+      C.close(self.socket)
+      self.socket = nil
+   end
    -- clear the mmap-ed memory
    self:free_mem_table()
 

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -61,16 +61,16 @@ function nfvconfig (pciaddr, confpath_x, confpath_y, nloads)
 
    for i=1, nloads do
       -- Load and apply confpath_x.
-      config.apply(config.load(confpath_x, pciaddr, "/dev/null"))
+      engine.configure(nfvconfig.load(confpath_x, pciaddr, "/dev/null"))
 
       -- Measure loading y.
       local start_load = C.get_monotonic_time()
-      local c, zerocopy = config.load(confpath_y, pciaddr, "/dev/null")
+      local c = nfvconfig.load(confpath_y, pciaddr, "/dev/null")
       local end_load = C.get_monotonic_time()
 
       -- Measure apply x -> y.
       local start_apply = C.get_monotonic_time()
-      config.apply(c, zerocopy)
+      engine.configure(c)
       local end_apply = C.get_monotonic_time()
 
       -- Push results.

--- a/src/program/snabbnfv/README.md
+++ b/src/program/snabbnfv/README.md
@@ -13,13 +13,8 @@ Neutron](https://wiki.openstack.org/wiki/Neutron).
 
 Loads the NFV configuration from *file* and compiles an app network using
 *pci_address* and *socket_path* for the underlying `Intel10G` and
-`VhostUser` apps. Returns the resulting engine configuration and
-*zerocopy pairs*.
+`VhostUser` apps. Returns the resulting engine configuration.
 
-— Function **nfvconfig.apply** *config*, *zerocopy*
-
-Configures the engine to use *config* and assign *zerocopy* pairs. Uses
-`engine.configure()` internally.
 
 #### NFV Configuration Format
 

--- a/src/program/snabbnfv/README.md.src
+++ b/src/program/snabbnfv/README.md.src
@@ -26,13 +26,8 @@ Neutron](https://wiki.openstack.org/wiki/Neutron).
 
 Loads the NFV configuration from *file* and compiles an app network using
 *pci_address* and *socket_path* for the underlying `Intel10G` and
-`VhostUser` apps. Returns the resulting engine configuration and
-*zerocopy pairs*.
+`VhostUser` apps. Returns the resulting engine configuration.
 
-— Function **nfvconfig.apply** *config*, *zerocopy*
-
-Configures the engine to use *config* and assign *zerocopy* pairs. Uses
-`engine.configure()` internally.
 
 #### NFV Configuration Format
 

--- a/src/program/snabbnfv/nfvconfig.lua
+++ b/src/program/snabbnfv/nfvconfig.lua
@@ -16,7 +16,7 @@ function port_name (port_config)
 end
 
 -- Compile app configuration from <file> for <pciaddr> and vhost_user
--- <socket>. Returns configuration and zerocopy pairs.
+-- <socket>. Returns configuration.
 function load (file, pciaddr, sockpath)
    local device_info = pci.device_info(pciaddr)
    if not device_info then
@@ -91,15 +91,8 @@ function load (file, pciaddr, sockpath)
       config.link(c, VM_tx.." -> "..NIC..".rx")
    end
 
-   -- Return configuration c, and zerocopy pairs.
+   -- Return configuration c.
    return c
-end
-
--- Apply configuration <c> to engine and reset <zerocopy> buffers.
-function apply (c, zerocopy)
---   print(config.graphviz(c))
---   main.exit(0)
-   engine.configure(c)
 end
 
 function selftest ()
@@ -120,7 +113,7 @@ function selftest ()
                               "program/snabbnfv/test_fixtures/nfvconfig/scale_change/y"})
    do
       print("testing:", confpath)
-      apply(load(confpath, pcideva, "/dev/null"))
+      engine.configure(load(confpath, pcideva, "/dev/null"))
       engine.main({duration = 0.25})
    end
 end

--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -41,7 +41,7 @@ function traffic (pciaddr, confpath, sockpath)
          local mtime2 = C.stat_mtime(confpath)
          if mtime2 ~= mtime then
             print("Loading " .. confpath)
-            nfvconfig.apply(nfvconfig.load(confpath, pciaddr, sockpath))
+            engine.configure(nfvconfig.load(confpath, pciaddr, sockpath))
             mtime = mtime2
          end
          engine.main({duration=1})
@@ -62,7 +62,7 @@ function bench (pciaddr, confpath, sockpath, npackets)
    engine.Hz = false
 
    print("Loading " .. confpath)
-   nfvconfig.apply(nfvconfig.load(confpath, pciaddr, sockpath))
+   engine.configure(nfvconfig.load(confpath, pciaddr, sockpath))
 
    -- From designs/nfv
    local start, packets, bytes = 0, 0, 0


### PR DESCRIPTION
[nfvconfig] Remove obsolete notion of "zerocopy pairs" and the related `nfvconfig.apply` function.

This also fixes a bug in `vhost_user` where it tried to `close(2)` a nil value. Additionally this makes `vhost_user:close` set `self.socket` to nil instead of -1 in order to avoid possible bugs when using `assert`.