### PR TITLE
neutron2snabb: get profile:bindings from vif_details

### DIFF
--- a/src/program/snabbnfv/neutron2snabb/neutron2snabb.lua
+++ b/src/program/snabbnfv/neutron2snabb/neutron2snabb.lua
@@ -48,7 +48,7 @@ function create_config (input_dir, output_dir, hostname)
       if binding.driver == "snabb" then
          local vif_details = json.decode(binding.vif_details)
          -- pcall incase the field is missing
-         local status, profile = pcall(json.decode, binding.profile)
+         local profile = vif_details["binding:profile"]
          profile = profile or {}
          if vif_details.zone_host == hostname then
             local zone_port = vif_details.zone_port


### PR DESCRIPTION
profile:bindings is not stored in the ml2_port_bindigs table
after the actual binding happens (i.e. the vm boots).
mechanism_snabb will store the value in the vif_details for persistence.