### PR TITLE
Bypass core.apps.restart_dead_apps() if restart mechanism is disabled

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -52,6 +52,7 @@ end
 
 -- Restart dead apps.
 function restart_dead_apps ()
+   if not use_restart then return end
    local restart_delay = 2 -- seconds
    local actions = { start={}, restart={}, reconfig={}, keep={}, stop={} }
    local restart = false


### PR DESCRIPTION
The "action" table is allocated each time the function is called,
which creates a fair amount of garbage, even if the restart mechanism
isn't actually used, which is the default.

This commit includes a bypass of the function if use_restart is false.

The dead-app detection code probably contains more of this kind of
garbage, e.g. in the apply_config_action() function.