### PR TITLE
core: Count "frees per second" (fps) and do dynamic idling

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -23,10 +23,31 @@ link_table, link_array = {}, {}
 
 configuration = config.new()
 
--- Count of the number of breaths taken
-breaths = 0
--- Ideal number of breaths per second
+-- Counters for statistics.
+-- TODO: Move these over to the counters framework
+breaths = 0			-- Total breaths taken
+frees   = 0			-- Total packets freed
+freebytes = 0			-- Total packet bytes freed
+
+-- Breathing regluation to reduce CPU usage when idle by calling usleep(3).
+--
+-- There are two modes available:
+--
+--   Hz = <n> means to aim for an exact <n> breaths per second rhythm
+--   Hz = false means dynamic adjustment of the breathing interval
+--
+-- Dynamic adjustment automatically scales the time to sleep between
+-- breaths from nothing up to maxsleep (default: 100us). If packets
+-- are processed during a breath then the sleep period is halved, and
+-- if no packets are processed during a breath then the sleep interval
+-- is increased by one microsecond.
+--
+-- The default is dynamic adjustment which should work well for the
+-- majority of cases.
+
 Hz = false
+sleep = 0
+maxsleep = 100
 
 -- Return current monotonic time in seconds.
 -- Can be used to drive timers in apps.
@@ -211,6 +232,8 @@ function main (options)
 end
 
 local nextbreath
+local lastfrees = 0
+local lastfreebytes = 0
 -- Wait between breaths to keep frequency with Hz.
 function pace_breathing ()
    if Hz then
@@ -221,6 +244,15 @@ function pace_breathing ()
          monotonic_now = C.get_monotonic_time()
       end
       nextbreath = math.max(nextbreath + 1/Hz, monotonic_now)
+   else
+      if lastfrees == frees then
+	 sleep = math.min(sleep + 1, maxsleep)
+	 C.usleep(sleep)
+      else
+	 sleep = math.floor(sleep/2)
+      end
+      lastfrees = frees
+      lastfreebytes = freebytes
    end
 end
 
@@ -263,32 +295,73 @@ function breathe ()
 end
 
 function report (options)
+   if not options or options.showload then
+      report_load()
+   end
+   if options and options.showlinks then
+      report_links()
+   end
+   if options and options.showapps then
+      report_apps()
+   end
+end
+
+-- Load reporting prints several metrics:
+--   time - period of time that the metrics were collected over
+--   fps  - frees per second (how many calls to packet.free())
+--   fpb  - frees per breath
+--   bpp  - bytes per packet (average packet size)
+local lastloadreport = nil
+local reportedfrees = nil
+local reportedbreaths = nil
+function report_load ()
+   if lastloadreport then
+      local interval = now() - lastloadreport
+      local newfrees   = frees - reportedfrees
+      local newbytes   = freebytes - reportedfreebytes
+      local newbreaths = breaths - reportedbreaths
+      local fps = math.floor(newfrees/interval)
+      local fpb = math.floor(newfrees/newbreaths)
+      local bpp = math.floor(newbytes/newfrees)
+      print(("load: time: %-2.2fs  fps: %-11s fpb: %-4s bpp: %-4s sleep: %-4dus"):format(
+	    interval,
+	    lib.comma_value(fps),
+	    lib.comma_value(fpb),
+	    (bpp ~= bpp) and "-" or tostring(bpp), -- handle NaN
+	    sleep))
+   end
+   lastloadreport = now()
+   reportedfrees = frees
+   reportedfreebytes = freebytes
+   reportedbreaths = breaths
+end
+
+function report_links ()
+   print("link report:")
    local function loss_rate(drop, sent)
       sent = tonumber(sent)
       if not sent or sent == 0 then return 0 end
       return tonumber(drop) * 100 / (tonumber(drop)+sent)
    end
-   if not options or options.showlinks then
-      print("link report:")
-      local names = {}
-      for name in pairs(link_table) do table.insert(names, name) end
-      table.sort(names)
-      for i, name in ipairs(names) do
-	 l = link_table[name]
-         print(("%20s sent on %s (loss rate: %d%%)"):format(
-		  lib.comma_value(l.stats.txpackets),
-		  name, loss_rate(l.stats.txdrop, l.stats.txpackets)))
-      end
+   local names = {}
+   for name in pairs(link_table) do table.insert(names, name) end
+   table.sort(names)
+   for i, name in ipairs(names) do
+      l = link_table[name]
+      print(("%20s sent on %s (loss rate: %d%%)"):format(
+	    lib.comma_value(l.stats.txpackets),
+	    name, loss_rate(l.stats.txdrop, l.stats.txpackets)))
    end
-   if options and options.showapps then
-      print ("apps report")
-      for name, app in pairs(app_table) do
-         if app.dead then
-            print (name, ("[dead: %s]"):format(app.dead.error))
-         elseif app.report then
-            print (name)
-            with_restart(app, app.report)
-         end
+end
+
+function report_apps ()
+   print ("apps report:")
+   for name, app in pairs(app_table) do
+      if app.dead then
+	 print(name, ("[dead: %s]"):format(app.dead.error))
+      elseif app.report then
+	 print(name)
+	 with_restart(app, app.report)
       end
    end
 end

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -238,6 +238,7 @@ function hexundump(h, n)
 end
 
 function comma_value(n) -- credit http://richard.warburton.it
+   if n ~= n then return "NaN" end
    local left,num,right = string.match(n,'^([^%d]*%d)(%d*)(.-)$')
    return left..(num:reverse():gsub('(%d%d%d)','%1,'):reverse())..right
 end

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -76,10 +76,15 @@ function from_pointer (ptr, len) return append(allocate(), ptr, len) end
 function from_string (d)         return from_pointer(d, #d) end
 
 -- Free a packet that is no longer in use.
-function free (p)
-   --ffi.fill(p, header_size, 0)
+local function free_internal (p)
    p.length = 0
    freelist_add(packets_fl, p)
+end   
+
+function free (p)
+   engine.frees = engine.frees + 1
+   engine.freebytes = engine.freebytes + p.length
+   free_internal(p)
 end
 
 -- Return pointer to packet data.
@@ -94,7 +99,7 @@ function preallocate_step()
    end
 
    for i=1, packet_allocation_step do
-      free(new_packet())
+      free_internal(new_packet(), true)
    end
    packets_allocated = packets_allocated + packet_allocation_step
    packet_allocation_step = 2 * packet_allocation_step

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -84,6 +84,9 @@ end
 function free (p)
    engine.frees = engine.frees + 1
    engine.freebytes = engine.freebytes + p.length
+   -- Calculate bits of physical capacity required for packet on 10GbE
+   -- Account for minimum data size and overhead of CRC and inter-packet gap
+   engine.freebits = engine.freebits + (math.max(p.length, 46) + 4 + 5) * 8
    free_internal(p)
 end
 

--- a/src/program/snabbnfv/traffic/README
+++ b/src/program/snabbnfv/traffic/README
@@ -1,5 +1,11 @@
 snabbnfv traffic [OPTIONS] <pci-address> <config-file> <socket-path>
 
+  -k SECONDS, --link-report-interval SECONDS
+                             Print an link status report every SECONDS.
+			     Default: 60s
+  -l SECONDS, --load-report-interval SECONDS
+                             Print a processing load report every SECONDS.
+			     Default: 1s
   -B NPACKETS, --benchmark NPACKETS
                              Benchmark processing NPACKETS.
   -h, --help

--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -64,7 +64,7 @@ end
 function bench (pciaddr, confpath, sockpath, npackets)
    npackets = tonumber(npackets)
    local ports = dofile(confpath)
-   local nic = "NIC_"..(nfvconfig.port_name(ports[1]))
+   local nic = (nfvconfig.port_name(ports[1])).."_NIC"
    engine.log = true
    engine.Hz = false
 


### PR DESCRIPTION
"Frees per second" (fps), literally the number of calls to
packet.free() per second, is introduced as a new basic metric for
measuring work done by a Snabb Switch process.

engine.Hz = false now uses a dynamic mechanism to decide how long to
sleep for depending on how busy/idle the process is, as observed from
fps. This is now the default setting and should be suitable for normal
usage.

Load on the process can be printed by calling
engine.report_load(). The load report looks like this:

    load: time: 1.00s  fps: 2,025,221   fpb: 304  bpp: 1280 sleep: 0   us

and the metrics mean:

    time - period of time that the metrics were collected over
    fps  - frees per second
    fpb  - frees per breath
    bpp  - bytes per packet (average packet size)