### PR TITLE
deps/luajit: Use github mirror of LuaJIT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/luajit"]
 	path = deps/luajit
-	url = http://luajit.org/git/luajit-2.0.git
+	url = http://github.com/SnabbCo/luajit.git
         ignore = dirty
 [submodule "deps/ljsyscall"]
 	path = deps/ljsyscall


### PR DESCRIPTION
The upstream luajit.org git repository has automatic usage quotas the
we were exceeding them from the Snabb Lab's IP address. (Source:
private correspondence with Mike Pall.)