### PR TITLE
[packetblaster] Update `is_device_suitable' for solarflare changes

### DIFF
--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -46,7 +46,7 @@ function run (args)
 end
 
 function is_device_suitable (pcidev, patterns)
-   if not pcidev.usable or pcidev.driver ~= 'apps.intel.intel10g' then
+   if not pcidev.usable or pcidev.driver ~= 'apps.intel.intel_app' then
       return false
    end
    if #patterns == 0 then


### PR DESCRIPTION
Fixes a regression introduced by the solarflare branch:

```
> @@ -54,9 +54,12 @@ function path(pcidev) return
"/sys/bus/pci/devices/"..pcidev end
>  -- Return the name of the Lua module that implements support for this
device.
>  function which_driver (vendor, device)
>     if vendor == '0x8086' then
> -      if device == '0x10fb' then return 'apps.intel.intel10g' end --
Intel 82599
> -      if device == '0x10d3' then return 'apps.intel.intel' end    --
Intel 82574L
> -      if device == '0x105e' then return 'apps.intel.intel' end    --
Intel 82571
> +      if device == '0x10fb' then return 'apps.intel.intel_app' end --
Intel 82599
```

Thanks to @alexandergall for finding this.