### PR TITLE
Virtio maint

### DIFF
--- a/src/apps/vhost/vhost_user.c
+++ b/src/apps/vhost/vhost_user.c
@@ -94,9 +94,6 @@ int vhost_user_send(int sock, struct vhost_user_msg *msg)
     msgh.msg_control = 0;
     msgh.msg_controllen = 0;
 
-    printf("vhost_user_send %d %d %d %d\n", msg->request, msg->flags, msg->size,
-            (int) iov[0].iov_len);
-
     do {
         ret = sendmsg(sock, &msgh, 0);
     } while (ret < 0 && errno == EINTR);

--- a/src/apps/vhost/vhost_user.lua
+++ b/src/apps/vhost/vhost_user.lua
@@ -210,6 +210,8 @@ end
 
 function VhostUser:reset_owner (msg)
    debug("reset_owner")
+   -- Disable vhost processing until the guest reattaches.
+   self.vhost_ready = false
 end
 
 function VhostUser:set_vring_num (msg)

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -224,7 +224,11 @@ function VirtioNetDevice:tx_packet_start(addr, len)
 
    -- TODO: copy the relevnat fields from the packet
    ffi.fill(tx_hdr, virtio_net_hdr_size)
-   tx_hdr.flags = validflags(tx_p.data+14, tx_p.length-14)
+   if band(self.features, C.VIRTIO_NET_F_CSUM) == 0 then
+      tx_hdr.flags = 0
+   else
+      tx_hdr.flags = validflags(tx_p.data+14, tx_p.length-14)
+   end
 
    return tx_p
 end

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -338,21 +338,23 @@ end
 
 function VirtioNetDevice:map_from_guest (addr)
    local result
+   local m = self.mem_table[0]
+   -- Check cache first (on-trace fastpath)
+   if addr >= m.guest and addr < m.guest + m.size then
+      return addr + m.snabb - m.guest
+   end
+   -- Looping case
    for i = 0, table.getn(self.mem_table) do
-      local m = self.mem_table[i]
+      m = self.mem_table[i]
       if addr >= m.guest and addr < m.guest + m.size then
          if i ~= 0 then
             self.mem_table[i] = self.mem_table[0]
             self.mem_table[0] = m
          end
-         result = addr + m.snabb - m.guest
-         break
+         return addr + m.snabb - m.guest
       end
    end
-   if not result then
-      error("mapping to host address failed" .. tostring(ffi.cast("void*",addr)))
-   end
-   return result
+   error("mapping to host address failed" .. tostring(ffi.cast("void*",addr)))
 end
 
 function VirtioNetDevice:map_from_qemu (addr)

--- a/src/lib/virtio/virtq.lua
+++ b/src/lib/virtio/virtq.lua
@@ -101,9 +101,10 @@ end
 -- Prepared argument for writing a 1 to an eventfd.
 local eventfd_one = ffi.new("uint64_t[1]", {1})
 
-function VirtioVirtq:signal_used()
+function VirtioVirtq:signal_used ()
    if self.virtq.used.idx ~= self.used then
       self.virtq.used.idx = self.used
+      C.full_memory_barrier()
       if band(self.virtq.avail.flags, C.VRING_F_NO_INTERRUPT) == 0 then
          C.write(self.callfd, eventfd_one, 8)
       end


### PR DESCRIPTION
I have been torture-testing our vhost-user implementation under extreme conditions. This works very well now. This branch contains the fixes that I made along the way.

* Topology: `UbuntuVM1 - snabb1 - 10G - snabb2 - UbuntuVM2`
* Continuous traffic for hours (parallel iperf / ping flood).
* Continuous restarts of `snabb2` process (every ~10s).
* Continuous reboots of `VM2`.

I also made one related [change](https://github.com/SnabbCo/qemu/commit/d57042c73a6db5b2c4be74770e91f0a64086bdfd) to the QEMU side of vhost-user to protect guest memory from vhost DMA during reboots.
