### PR TITLE
Enable MTU configuration and add SNMP objects to intel10g driver

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -746,6 +746,8 @@ function M_pf:new_vf (poolnum)
       -- some things are shared with the main device...
       base = self.base,             -- mmap()ed register file
       s = self.s,                   -- Statistics registers
+      mtu = self.mtu,
+      snmp = self.snmp,
       -- and others are our own
       r = {},                       -- Configuration registers
       poolnum = poolnum,

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -34,7 +34,7 @@ function Intel82599:new (arg)
 
    if conf.vmdq then
       if devices[conf.pciaddr] == nil then
-         devices[conf.pciaddr] = {pf=intel10g.new_pf(conf.pciaddr):open(), vflist={}}
+         devices[conf.pciaddr] = {pf=intel10g.new_pf(conf):open(), vflist={}}
       end
       local dev = devices[conf.pciaddr]
       local poolnum = firsthole(dev.vflist)-1
@@ -42,7 +42,7 @@ function Intel82599:new (arg)
       dev.vflist[poolnum+1] = vf
       return setmetatable({dev=vf:open(conf)}, Intel82599)
    else
-      local dev = intel10g.new_sf(conf.pciaddr):open()
+      local dev = intel10g.new_sf(conf):open()
       if not dev then return null end
       return setmetatable({dev=dev, zone="intel"}, Intel82599)
    end


### PR DESCRIPTION
I need to be able to configure the MTU of individual interfaces. This requires functionality to pass configuration options down to the driver. I suggest a simple method, where the config supplied to Intel82599 is passed on to the intel10g module unchanged.

There is no consesus about what should be included in the MTU among vendors. For example, IOS does not include the Ethernet header, while IOS-XR and JunOS does.  Others include the CRC as well. I suggest the convention to include the Ethernet header but not the CRC.

Finally, I've added support for most of the objects in the ifMIB and interfaces MIB, which makes it possible to monitor an interface with standard tools.