### PR TITLE
Don't print the backtrace on error messages by default

### DIFF
--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -93,7 +93,9 @@ end
 
 function handler (reason)
    print(reason)
-   print(debug.traceback())
+   if debug_on_error or os.getenv("SNABB_BACKTRACE") then
+      print(debug.traceback())
+   end
    if debug_on_error then debug.debug() end
    os.exit(1)
 end


### PR DESCRIPTION
This is an idea for review: Do not print the Lua traceback (stack trace) for errors unless the environment variable SNABB_BACKTRACE is set.

The problem this addresses is that simple program errors often look pretty scary. For example, in `snabbnfv traffic` you will see a Lua traceback if you try to use a NIC that is already in use.

On the one hand I don't think we ever want end-users to see Lua tracebacks (unless when reporting bugs). On the other hand I do think that developers always want to see them.

Is this a good solution? If not then what might be better?