### PR TITLE
apps/packet_filter: Rename pcap_filter.PcapFilter to bpf.BPF

### DIFF
--- a/src/apps/packet_filter/README.md
+++ b/src/apps/packet_filter/README.md
@@ -1,20 +1,20 @@
-# PcapFilter App (apps.packet_filter.pcap_filter)
+# BPF App (apps.packet_filter.bpf.BPF)
 
-The `PcapFilter` app receives packets on the `input` port and transmits
+The `BPF` app receives packets on the `input` port and transmits
 conforming packets to the `output` port. In order to conform, a packet
 must match the *[pcap-filter](http://www.tcpdump.org/manpages/pcap-filter.7.html)
-expression* of the `PcapFilter` instance and/or belong to a *sanctioned
+expression* of the `BPF` instance and/or belong to a *sanctioned
 connection*. For a connection to be sanctioned it must be tracked in a
-*state table* by a `PcapFilter` app using the same state table. All
-`PcapFilter` apps share a global namespace of *state table identifiers*.
-Multiple `PcapFilter` apps—e.g. for inbound and outbound traffic—can
+*state table* by a `BPF` app using the same state table. All
+`BPF` apps share a global namespace of *state table identifiers*.
+Multiple `BPF` apps—e.g. for inbound and outbound traffic—can
 refer to the same connection by sharing a state table identifer.
 
-![PcapFilter](.images/PcapFilter.png)
+![BPF](.images/BPF.png)
 
 ## Configuration
 
-The `PcapFilter` app accepts a table as its configuration argument. The
+The `BPF` app accepts a table as its configuration argument. The
 following keys are available:
 
 — Key **filter**

--- a/src/apps/packet_filter/README.md.src
+++ b/src/apps/packet_filter/README.md.src
@@ -1,25 +1,25 @@
-# PcapFilter App (apps.packet_filter.pcap_filter)
+# BPF App (apps.packet_filter.bpf.BPF)
 
-The `PcapFilter` app receives packets on the `input` port and transmits
+The `BPF` app receives packets on the `input` port and transmits
 conforming packets to the `output` port. In order to conform, a packet
 must match the *[pcap-filter](http://www.tcpdump.org/manpages/pcap-filter.7.html)
-expression* of the `PcapFilter` instance and/or belong to a *sanctioned
+expression* of the `BPF` instance and/or belong to a *sanctioned
 connection*. For a connection to be sanctioned it must be tracked in a
-*state table* by a `PcapFilter` app using the same state table. All
-`PcapFilter` apps share a global namespace of *state table identifiers*.
-Multiple `PcapFilter` apps—e.g. for inbound and outbound traffic—can
+*state table* by a `BPF` app using the same state table. All
+`BPF` apps share a global namespace of *state table identifiers*.
+Multiple `BPF` apps—e.g. for inbound and outbound traffic—can
 refer to the same connection by sharing a state table identifer.
 
-    DIAGRAM: PcapFilter
+    DIAGRAM: BPF
                +------------+
                |            |
-    input ---->* PcapFilter *----> output
+    input ---->*    BPF     *----> output
                |            |
                +------------+
 
 ## Configuration
 
-The `PcapFilter` app accepts a table as its configuration argument. The
+The `BPF` app accepts a table as its configuration argument. The
 following keys are available:
 
 — Key **filter**

--- a/src/program/snabbnfv/README.md
+++ b/src/program/snabbnfv/README.md
@@ -28,7 +28,7 @@ return { <port-1>, ..., <port-n> }
 
 Each port is defined by a range of properties which correspond to the
 configuration parameters of the underlying apps (NIC driver, `VhostUser`,
-`PcapFilter`, `RateLimiter`, `nd_light` and `SimpleKeyedTunnel`):
+`BPF`, `RateLimiter`, `nd_light` and `SimpleKeyedTunnel`):
 
 ```
 port := { port_id        = <id>,          -- A unique string

--- a/src/program/snabbnfv/README.md.src
+++ b/src/program/snabbnfv/README.md.src
@@ -41,7 +41,7 @@ return { <port-1>, ..., <port-n> }
 
 Each port is defined by a range of properties which correspond to the
 configuration parameters of the underlying apps (NIC driver, `VhostUser`,
-`PcapFilter`, `RateLimiter`, `nd_light` and `SimpleKeyedTunnel`):
+`BPF`, `RateLimiter`, `nd_light` and `SimpleKeyedTunnel`):
 
 ```
 port := { port_id        = <id>,          -- A unique string

--- a/src/program/snabbnfv/fuzz/fuzz.lua
+++ b/src/program/snabbnfv/fuzz/fuzz.lua
@@ -129,7 +129,7 @@ function random_filter_rule ()
    local ethertype = random_item(options.ethertype)
    local source_port_min = random_port()
    local dest_port_min = random_port()
-   -- See PcapFilter (apps.packet_filter.pcap_filter)
+   -- See BPF (apps.packet_filter.BPF)
    return ("(%s and %s and src net %s and dst net %s and src portrange %d-%d and dst portrange %d-%d)"):format(
       ethertype,
       random_item(options.protocol),

--- a/src/program/snabbnfv/nfvconfig.lua
+++ b/src/program/snabbnfv/nfvconfig.lua
@@ -1,7 +1,7 @@
 module(...,package.seeall)
 
 local VhostUser = require("apps.vhost.vhost_user").VhostUser
-local PcapFilter = require("apps.packet_filter.pcap_filter").PcapFilter
+local BPF = require("apps.packet_filter.bpf").BPF
 local RateLimiter = require("apps.rate_limiter.rate_limiter").RateLimiter
 local nd_light = require("apps.ipv6.nd_light").nd_light
 local L2TPv3 = require("apps.keyed_ipv6_tunnel.tunnel").SimpleKeyedTunnel
@@ -50,15 +50,15 @@ function load (file, pciaddr, sockpath)
       local pf_state_table = t.stateful_filter and name
       if t.ingress_filter then
          local Filter = name.."_Filter_in"
-         config.app(c, Filter, PcapFilter, { filter = t.ingress_filter,
-                                             state_table = pf_state_table })
+         config.app(c, Filter, BPF, { filter = t.ingress_filter,
+                                      state_table = pf_state_table })
          config.link(c, Filter..".tx -> " .. VM_rx)
          VM_rx = Filter..".rx"
       end
       if t.egress_filter then
          local Filter = name..'_Filter_out'
-         config.app(c, Filter, PcapFilter, { filter = t.egress_filter,
-                                             state_table = pf_state_table })
+         config.app(c, Filter, BPF, { filter = t.egress_filter,
+                                      state_table = pf_state_table })
          config.link(c, VM_tx..' -> '..Filter..'.rx')
          VM_tx = Filter..'.tx'
       end

--- a/src/program/snabbnfv/traffic/README
+++ b/src/program/snabbnfv/traffic/README
@@ -28,7 +28,7 @@ CONFIG FILE FORMAT:
 
   Each port is defined by a range of properties which correspond to the
   configuration parameters of the underlying apps (NIC driver, VhostUser,
-  PcapFilter, RateLimiter, nd_light and SimpleKeyedTunnel):
+  BPF, RateLimiter, nd_light and SimpleKeyedTunnel):
 
       port := { port_id        = <id>,          -- A unique string
                 mac_address    = <mac-address>, -- MAC address as a string


### PR DESCRIPTION
Give a new shorter name to the pflua based packet filter app.

The name BPF is a reference to the Berkeley Packet Filter where the pflang filter language originated (before being adopted by libpcap).

- http://en.wikipedia.org/wiki/Berkeley_Packet_Filter
- http://www.tcpdump.org/papers/bpf-usenix93.pdf

This name is somewhat ambiguous in that BPF can refer to a larger body of software including the `/dev/bpf` packet capture device on *BSD. However, the name Pcap has the same ambiguity of pcap-filter
vs libpcap, and networking people seem to prefer "BPF" to "PcapFilter".

This is motivated by comments [by Kristian](https://github.com/SnabbCo/snabbswitch/pull/444#issuecomment-91796187) and [by Simon](https://groups.google.com/d/msg/snabb-devel/eOMS8zZWi90/CgjGjmbcZIkJ).

Speak ye now or forever hold your peace on the name of the pflua filtering app! This PR can easily be replaced by a new one if we hit upon a better name.