### PR TITLE
snabbnfv traffic: Add -D/--debug-report-interval argument

### DIFF
--- a/src/program/snabbnfv/traffic/README
+++ b/src/program/snabbnfv/traffic/README
@@ -6,6 +6,10 @@ snabbnfv traffic [OPTIONS] <pci-address> <config-file> <socket-path>
   -l SECONDS, --load-report-interval SECONDS
                              Print a processing load report every SECONDS.
 			     Default: 1s
+  -D SECONDS, --debug-report-interval SECONDS
+                             Print a debug report every SECONDS.
+			     The debug report includes a NIC register dump.
+			     Default: 600s (10 minutes)
   -B NPACKETS, --benchmark NPACKETS
                              Benchmark processing NPACKETS.
   -h, --help

--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -12,6 +12,7 @@ local long_opts = {
    help          = "h",
    ["link-report-interval"] = "k",
    ["load-report-interval"] = "l",
+   ["debug-report-interval"] = "D",
    ["long-help"] = "H"
 }
 
@@ -20,12 +21,14 @@ function run (args)
    local benchpackets
    local linkreportinterval = 60
    local loadreportinterval = 1
+   local debugreportinterval = 600
    function opt.B (arg) benchpackets = tonumber(arg)      end
    function opt.h (arg) print(short_usage()) main.exit(1) end
    function opt.H (arg) print(long_usage())  main.exit(1) end
    function opt.k (arg) linkreportinterval = tonumber(arg) end
    function opt.l (arg) loadreportinterval = tonumber(arg) end
-   args = lib.dogetopt(args, opt, "hHB:k:l:", long_opts)
+   function opt.D (arg) debugreportinterval = tonumber(arg) end
+   args = lib.dogetopt(args, opt, "hHB:k:l:D:", long_opts)
    if #args == 3 then
       local pciaddr, confpath, sockpath = unpack(args)
       if loadreportinterval > 0 then
@@ -34,6 +37,10 @@ function run (args)
       end
       if linkreportinterval > 0 then
 	 local t = timer.new("nfvlinkreport", engine.report_links, linkreportinterval*1e9, 'repeating')
+	 timer.activate(t)
+      end
+      if debugreportinterval > 0 then
+	 local t = timer.new("nfvdebugreport", engine.report_apps, debugreportinterval*1e9, 'repeating')
 	 timer.activate(t)
       end
       if benchpackets then


### PR DESCRIPTION
The debug report calls engine.app_report() to report on the internal state of the apps in the network. This notably includes a register dump from the NIC.

The debug report for a simple configuration currently looks like this:

```
apps report:
A_NIC
report on intel device  0000:01:00.0
                GORCL[00004088]:15c4f40c (     365,227,668) Good Octets Received Count Low
                GOTCH[00004094]:00000002 (               2) Good Octets Transmitted Count High
                GOTCL[00004090]:7b7299c4 (   2,071,101,684) Good Octets Transmitted Count Low
                 GPRC[00004074]:0027cc30 (       2,608,176) Good Packets Received Count
                 GPTC[00004080]:006671c1 (       6,713,789) Good Packets Transmitted Count
                 MLFC[00004034]:00000002 (               2) MAC Local Fault Count
                 MPTC[000040f0]:00000002 (               2) Multicast Packets Transmitted Count
                 MRFC[00004038]:00000001 (               1) MAC Remote Fault Count
               PRC127[00004060]:00000002 (               2) Packets Received [65-127 Bytes] Count
               PRC255[00004064]:0027cc49 (       2,608,201) Packets Received [128-255 Bytes] Count
              PTC1023[000040e8]:00000097 (             151) Packets Transmitted [512-1023 Bytes] Count
               PTC127[000040dc]:00000002 (               2) Packets Transmitted [65-127 Bytes] Count
              PTC1522[000040ec]:00667088 (       6,713,477) Packets Transmitted [Greater than 1024 Bytes] Count
               PTC255[000040e0]:000000d5 (             213) Packets Transmitted [128-255 Bytes] Count
               PTC511[000040e4]:00000014 (              20) Packets Transmitted [256-511 Bytes] Count
              RXDGBCL[00002f54]:1525eac4 (     354,806,468) DMA Good Rx Byte Counter Low
               RXDGPC[00002f50]:0027cc79 (       2,608,240) DMA Good Rx Packet Counter
             RXNFGBCL[000041b4]:15c52170 (     365,240,688) Good Rx Non-Filter Byte Counter Low
              RXNFGPC[000041b0]:0027cc7d (       2,608,249) Good Rx Non-Filtered Packet Counter
                 TORL[000040c0]:15c523a0 (     365,241,248) Total Octets Received
                  TPR[000040d0]:0027cc81 (       2,608,253) Total Packets Received
                  TPT[000040d4]:0066728b (       6,713,992) Total Packets Transmitted
              TXDGBCH[000087a8]:00000002 (               2) DMA Good Tx Byte Counter High
              TXDGBCL[000087a4]:79e11734 (   2,044,788,340) DMA Good Tx Byte Counter Low
               TXDGPC[000087a0]:0066730b (       6,714,119) DMA Good Tx Packet Counter
                AUTOC[000042a0]:c09c6084 Auto Negotiation Control
                LINKS[000042a4]:79081093 Link Status Register
                  RDH[00001010]:000000a5 Receive Descriptor Head
                  RDT[00001018]:000001c9 Receive Descriptor Tail
                  TDH[00006010]:0000013e Transmit Descriptor Head
                  TDT[00006018]:00000147 Transmit Descriptor Tail
```
