### PR TITLE
neutron_sync_master: Remove Neutron QoS from default tables

### DIFF
--- a/src/program/snabbnfv/neutron_sync_master/README
+++ b/src/program/snabbnfv/neutron_sync_master/README
@@ -20,8 +20,7 @@ available to snabbnfv-sync-agent processes running on other hosts.
                              Default: $DB_NEUTRON_TABLES or
                              "networks ports ml2_network_segments \
                              securitygroups securitygrouprules \
-                             securitygroupportbindings qos_policies \
-                             qoses portqosmappings"
+                             securitygroupportbindings"
   -m HOST, --mysql-host HOST
                              MySQL hostname.
                              Default: $DB_HOST or "localhost"

--- a/src/program/snabbnfv/neutron_sync_master/neutron_sync_master.lua
+++ b/src/program/snabbnfv/neutron_sync_master/neutron_sync_master.lua
@@ -27,7 +27,7 @@ function run (args)
       ["DB_HOST"]           = os.getenv("DB_HOST") or "localhost",
       ["DB_PORT"]           = os.getenv("DB_PORT") or "3306",
       ["DB_NEUTRON"]        = os.getenv("DB_NEUTRON") or "neutron_ml2",
-      ["DB_NEUTRON_TABLES"] = os.getenv("DB_NEUTRON_TABLES") or "networks ports ml2_network_segments securitygroups securitygrouprules securitygroupportbindings qos_policies qoses portqosmappings",
+      ["DB_NEUTRON_TABLES"] = os.getenv("DB_NEUTRON_TABLES") or "networks ports ml2_network_segments securitygroups securitygrouprules securitygroupportbindings",
       ["SYNC_LISTEN_HOST"]  = os.getenv("SYNC_LISTEN_HOST") or "127.0.0.1",
       ["SYNC_LISTEN_PORT"]  = os.getenv("SYNC_LISTEN_PORT") or "9418",
       ["SYNC_INTERVAL"]     = os.getenv("SYNC_INTERVAL") or "1"


### PR DESCRIPTION
The Neutron QoS feature is not used by recent Snabb NFV versions.

(The QoS API has not been merged into upstream Neutron after two years and so we don't want to depend on it.)