### PR TITLE
Move SIMD code into arch/avx2.c and arch/sse2.c

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,9 +18,10 @@ OBJDIR = $(patsubst %,obj/%,$(SRCDIR))
 LUASRC = $(shell find . -regex '[^\#]*\.lua' -printf '%P ')
 PFLUASRC = $(shell cd ../deps/pflua/src && \
 	         find . -regex '[^\#]*\.lua' -printf '%P ')
-CSRC   = $(shell find . -regex '[^\#]*\.c'   -printf '%P ')
-CHDR   = $(shell find . -regex '[^\#]*\.h'   -printf '%P ')
+CSRC   = $(shell find . -regex '[^\#]*\.c' -not -regex './arch/.*' -printf '%P ')
+CHDR   = $(shell find . -regex '[^\#]*\.h' -printf '%P ')
 ASM    = $(shell find . -regex '[^\#]*\.dasc' -printf '%P ')
+ARCHSRC= $(shell find . -regex '^./arch/[^\#]*\.c' -printf '%P ')
 RMSRC  = $(shell find . -name  README.md.src -printf '%P ')
 # regexp is to include program/foo but not program/foo/bar
 PROGRAM = $(shell find program -regex '^[^/]+/[^/]+' -type d -printf '%P ')
@@ -30,6 +31,7 @@ LUAOBJ := $(patsubst %.lua,obj/%_lua.o,$(LUASRC))
 PFLUAOBJ := $(patsubst %.lua,obj/%_lua.o,$(PFLUASRC))
 COBJ   := $(patsubst %.c,obj/%_c.o,    $(CSRC))
 HOBJ   := $(patsubst %.h,obj/%_h.o,    $(CHDR))
+ARCHOBJ:= $(patsubst %.c,obj/%_c.o,    $(ARCHSRC))
 ASMOBJ := $(patsubst %.dasc,obj/%_dasc.o,   $(ASM))
 JITOBJS:= $(patsubst %,obj/jit_%.o,$(JITSRC))
 EXTRAOBJS := obj/jit_tprof.o obj/jit_vmprof.o obj/strict.o
@@ -51,7 +53,7 @@ TESTSCRIPTS = $(shell find . -name "selftest.sh" -executable | xargs)
 
 PATH := ../deps/luajit/usr/local/bin:$(PATH)
 
-snabb: $(LUAOBJ) $(PFLUAOBJ) $(HOBJ) $(COBJ) $(ASMOBJ) $(INCOBJ) $(LUAJIT_A)
+snabb: $(LUAOBJ) $(PFLUAOBJ) $(HOBJ) $(COBJ) $(ARCHOBJ) $(ASMOBJ) $(INCOBJ) $(LUAJIT_A)
 	$(E) "SUBMODULES"
 	@if test ! -f ../deps/luajit.vsn			|| \
 	    test ! -f ../deps/ljsyscall.vsn			|| \
@@ -151,9 +153,13 @@ $(COBJ): obj/%_c.o: %.c $(CHDR) Makefile | $(OBJDIR)
 	$(E) "C         $@"
 	$(Q) gcc $(DEBUG) -Wl,-E -I ../deps/luajit/src -I . -include $(CURDIR)/../gcc-preinclude.h -c -Wall -Werror -o $@ $<
 
-obj/lib/checksum_c.o: lib/checksum.c
-	$(E) "C(O2)     $@"
-	$(Q) gcc -O2 -mavx2 -msse2 -Wl,-E -I ../deps/luajit/src -I . -include $(CURDIR)/../gcc-preinclude.h -c -Wall -Werror -o $@ $<
+obj/arch/avx2_c.o: arch/avx2.c Makefile
+	$(E) "C(AVX2)   $@"
+	$(Q) gcc -O2 -mavx2 $(DEBUG) -Wl,-E -I ../deps/luajit/src -I . -include $(CURDIR)/../gcc-preinclude.h -c -Wall -Werror -o $@ $<
+
+obj/arch/sse2_c.o: arch/sse2.c Makefile
+	$(E) "C(SSE2)   $@"
+	$(Q) gcc -O2 -msse2 $(DEBUG) -Wl,-E -I ../deps/luajit/src -I . -include $(CURDIR)/../gcc-preinclude.h -c -Wall -Werror -o $@ $<
 
 $(HOBJ): obj/%_h.o: %.h Makefile | $(OBJDIR)
 	$(E) "H         $@"

--- a/src/arch/avx2.c
+++ b/src/arch/avx2.c
@@ -1,0 +1,86 @@
+/* IP checksum routine for AVX2.
+ *
+ * Based on original SSE2 code by Tony Rogvall that is
+ * copyright 2011 Teclo Networks AG. MIT licensed by Juho Snellman.
+ */
+
+#include <stdint.h>
+#include <arpa/inet.h>
+#include <x86intrin.h>
+#include "lib/checksum_lib.h"
+
+// For fallback onto non-SIMD checksum:
+extern uint16_t cksum_generic(unsigned char *p, size_t n, uint32_t initial);
+
+static inline uint32_t cksum_avx2_loop(unsigned char *p, size_t n)
+{
+    __m256i sum0, sum1, zero;
+    uint32_t s[8] __attribute__((aligned(32))); // aligned for avx2 store
+    uint32_t sum2;
+
+    zero = _mm256_set_epi64x(0,0,0,0);
+    sum0 = zero;
+    sum1 = zero;
+
+    while(n) {
+        size_t k = (n >= 0xff) ? 0xff : n;
+        __m256i t0,t1;
+        __m256i s0 = zero;
+        __m256i s1 = zero;
+        n -= k;
+        while (k) {
+            __m256i src = _mm256_loadu_si256((__m256i const*) p);
+            __m256i t;
+
+            t = _mm256_unpacklo_epi8(src, zero);
+            s0 = _mm256_adds_epu16(s0, t);
+            t = _mm256_unpackhi_epi8(src, zero);
+            s1 = _mm256_adds_epu16(s1, t);
+            p += sizeof(src);
+            k--;
+        }
+
+        // LOW - combine S0 and S1 into sum0
+        t0 = _mm256_unpacklo_epi16(s0, zero);
+        sum0 = _mm256_add_epi32(sum0, t0);
+        t1 = _mm256_unpacklo_epi16(s1, zero);
+        sum1 = _mm256_add_epi32(sum1, t1);
+
+        // HIGH - combine S0 and S1 into sum1
+        t0 = _mm256_unpackhi_epi16(s0, zero);
+        sum0 = _mm256_add_epi32(sum0, t0);
+        t1 = _mm256_unpackhi_epi16(s1, zero);
+        sum1 = _mm256_add_epi32(sum1, t1);
+    }
+    // here we must sum the 4-32 bit sums into one 32 bit sum
+    _mm256_store_si256((__m256i*)s, sum0);
+    sum2 = (s[0]<<8) + s[1] + (s[2]<<8) + s[3] + (s[4]<<8) + s[5] + (s[6]<<8) + s[7];
+    _mm256_store_si256((__m256i*)s, sum1);
+    sum2 += (s[0]<<8) + s[1] + (s[2]<<8) + s[3] + (s[4]<<8) + s[5] + (s[6]<<8) + s[7];
+
+    return sum2;
+}
+
+uint16_t cksum_avx2(unsigned char *p, size_t n, uint32_t initial)
+{
+    uint32_t sum = ntohs(initial);
+
+    if (n < 128) { return cksum_generic(p, n, initial); }
+    if (n >= 64) {
+        size_t k = (n >> 5);
+        sum += cksum_avx2_loop(p, k);
+        n -= (32*k);
+        p += (32*k);
+    }
+    if (n > 1) {
+        size_t k = (n>>1);   // number of 16-bit words
+        sum += cksum_ua_loop(p, k);
+        n -= (2*k);
+        p += (2*k);
+    }
+    if (n)       // take care of left over byte
+        sum += (p[0] << 8);
+    while(sum>>16)
+        sum = (sum & 0xFFFF) + (sum>>16);
+    return (uint16_t)~sum;
+}

--- a/src/arch/sse2.c
+++ b/src/arch/sse2.c
@@ -1,0 +1,96 @@
+/* IP checksum routine for AVX2.
+ *
+ * Original code by Tony Rogvall that is
+ * copyright 2011 Teclo Networks AG. MIT licensed by Juho Snellman.
+ */
+
+#include <stdint.h>
+#include <arpa/inet.h>
+#include <x86intrin.h>
+#include "lib/checksum_lib.h"
+
+// For fallback onto non-SIMD checksum:
+extern uint16_t cksum_generic(unsigned char *p, size_t n, uint32_t initial);
+
+//
+// this loop may only run when data is aligned 16 byte aligned
+// n is number of 16 byte vectors
+//
+static inline uint32_t cksum_sse2_loop(unsigned char *p, size_t n)
+{
+  __m128i sum0, sum1, zero;
+  uint32_t s[4];
+  uint32_t sum2;
+
+  zero = _mm_set_epi32(0,0,0,0);
+  sum0 = zero;
+  sum1 = zero;
+
+  while(n) {
+    size_t k = (n >= 0xff) ? 0xff : n;
+    __m128i t0,t1;
+    __m128i s0 = zero;
+    __m128i s1 = zero;
+    n -= k;
+    while (k) {
+      __m128i src = _mm_load_si128((__m128i const*) p);
+      __m128i t;
+
+      t = _mm_unpacklo_epi8(src, zero);
+      s0 = _mm_adds_epu16(s0, t);
+      t = _mm_unpackhi_epi8(src, zero);
+      s1 = _mm_adds_epu16(s1, t);
+      p += sizeof(src);
+      k--;
+    }
+
+    // LOW - combine S0 and S1 into sum0
+    t0 = _mm_unpacklo_epi16(s0, zero);
+    sum0 = _mm_add_epi32(sum0, t0);
+    t1 = _mm_unpacklo_epi16(s1, zero);
+    sum1 = _mm_add_epi32(sum1, t1);
+
+    // HIGH - combine S0 and S1 into sum1
+    t0 = _mm_unpackhi_epi16(s0, zero);
+    sum0 = _mm_add_epi32(sum0, t0);
+    t1 = _mm_unpackhi_epi16(s1, zero);
+    sum1 = _mm_add_epi32(sum1, t1);
+  }
+  // here we must sum the 4-32 bit sums into one 32 bit sum
+  _mm_store_si128((__m128i*)s, sum0);
+  sum2 = (s[0]<<8) + s[1] + (s[2]<<8) + s[3];
+  _mm_store_si128((__m128i*)s, sum1);
+  sum2 += (s[0]<<8) + s[1] + (s[2]<<8) + s[3];
+  return sum2;
+}
+
+uint16_t cksum_sse2(unsigned char *p, size_t n, uint32_t initial)
+{
+  uint32_t sum = ntohs(initial);
+
+  if (n < 128) { return cksum_generic(p, n, initial); }
+  int unaligned = (unsigned long) p & 0xf;
+  if (unaligned) {
+    size_t k = (0x10 - unaligned) >> 1;
+    sum += cksum_ua_loop(p, k);
+    n -= (2*k);
+    p += (2*k);
+  }
+  if (n >= 32) {  // fast even with only two vectors
+    size_t k = (n >> 4);
+    sum += cksum_sse2_loop(p, k);
+    n -= (16*k);
+    p += (16*k);
+  }
+  if (n > 1) {
+    size_t k = (n>>1);   // number of 16-bit words
+    sum += cksum_ua_loop(p, k);
+    n -= (2*k);
+    p += (2*k);
+  }
+  if (n)       // take care of left over byte
+    sum += (p[0] << 8);
+  while(sum>>16)
+    sum = (sum & 0xFFFF) + (sum>>16);
+  return (uint16_t)~sum;
+}

--- a/src/lib/checksum.c
+++ b/src/lib/checksum.c
@@ -1,7 +1,9 @@
-/* IP checksum routines including x86 SIMD (SSE2 and AVX2).
- * SSE2 code by Tony Rogvall.
- * Copyright 2011 Teclo Networks AG. MIT licensed by Juho Snellman.
- * Generic code taken from DPDK: BSD license; (C) Intel 2010-2014, 6WIND 2014.
+/* IP checksum routines.
+ *
+ * See src/arch/ for architecture specific SIMD versions.
+ *
+ * Generic checksm routine taken from DPDK: 
+ *   BSD license; (C) Intel 2010-2015, 6WIND 2014.
  */
 
 #include <arpa/inet.h>
@@ -11,10 +13,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <sys/time.h>
-
-#include <x86intrin.h>
-
-// Portable C version
 
 static inline uint32_t cksum_generic_loop(const void *buf, size_t len, uint32_t sum)
 {
@@ -77,166 +75,6 @@ static inline uint32_t cksum_ua_loop(unsigned char *p, uint16_t n)
     n--;
   }
   return (s0<<8)+s1;
-}
-
-// SSE-2 version
-
-//
-// this loop may only run when data is aligned 16 byte aligned
-// n is number of 16 byte vectors
-//
-static inline uint32_t cksum_sse2_loop(unsigned char *p, size_t n)
-{
-  __m128i sum0, sum1, zero;
-  uint32_t s[4];
-  uint32_t sum2;
-
-  zero = _mm_set_epi32(0,0,0,0);
-  sum0 = zero;
-  sum1 = zero;
-
-  while(n) {
-    size_t k = (n >= 0xff) ? 0xff : n;
-    __m128i t0,t1;
-    __m128i s0 = zero;
-    __m128i s1 = zero;
-    n -= k;
-    while (k) {
-      __m128i src = _mm_load_si128((__m128i const*) p);
-      __m128i t;
-
-      t = _mm_unpacklo_epi8(src, zero);
-      s0 = _mm_adds_epu16(s0, t);
-      t = _mm_unpackhi_epi8(src, zero);
-      s1 = _mm_adds_epu16(s1, t);
-      p += sizeof(src);
-      k--;
-    }
-
-    // LOW - combine S0 and S1 into sum0
-    t0 = _mm_unpacklo_epi16(s0, zero);
-    sum0 = _mm_add_epi32(sum0, t0);
-    t1 = _mm_unpacklo_epi16(s1, zero);
-    sum1 = _mm_add_epi32(sum1, t1);
-
-    // HIGH - combine S0 and S1 into sum1
-    t0 = _mm_unpackhi_epi16(s0, zero);
-    sum0 = _mm_add_epi32(sum0, t0);
-    t1 = _mm_unpackhi_epi16(s1, zero);
-    sum1 = _mm_add_epi32(sum1, t1);
-  }
-  // here we must sum the 4-32 bit sums into one 32 bit sum
-  _mm_store_si128((__m128i*)s, sum0);
-  sum2 = (s[0]<<8) + s[1] + (s[2]<<8) + s[3];
-  _mm_store_si128((__m128i*)s, sum1);
-  sum2 += (s[0]<<8) + s[1] + (s[2]<<8) + s[3];
-  return sum2;
-}
-
-uint16_t cksum_sse2(unsigned char *p, size_t n, uint32_t initial)
-{
-  uint32_t sum = ntohs(initial);
-
-  if (n < 128) { return cksum_generic(p, n, initial); }
-  int unaligned = (unsigned long) p & 0xf;
-  if (unaligned) {
-    size_t k = (0x10 - unaligned) >> 1;
-    sum += cksum_ua_loop(p, k);
-    n -= (2*k);
-    p += (2*k);
-  }
-  if (n >= 32) {  // fast even with only two vectors
-    size_t k = (n >> 4);
-    sum += cksum_sse2_loop(p, k);
-    n -= (16*k);
-    p += (16*k);
-  }
-  if (n > 1) {
-    size_t k = (n>>1);   // number of 16-bit words
-    sum += cksum_ua_loop(p, k);
-    n -= (2*k);
-    p += (2*k);
-  }
-  if (n)       // take care of left over byte
-    sum += (p[0] << 8);
-  while(sum>>16)
-    sum = (sum & 0xFFFF) + (sum>>16);
-  return (uint16_t)~sum;
-}
-
-// AVX2 version
-
-static inline uint32_t cksum_avx2_loop(unsigned char *p, size_t n)
-{
-    __m256i sum0, sum1, zero;
-    uint32_t s[8] __attribute__((aligned(32))); // aligned for avx2 store
-    uint32_t sum2;
-
-    zero = _mm256_set_epi64x(0,0,0,0);
-    sum0 = zero;
-    sum1 = zero;
-
-    while(n) {
-        size_t k = (n >= 0xff) ? 0xff : n;
-        __m256i t0,t1;
-        __m256i s0 = zero;
-        __m256i s1 = zero;
-        n -= k;
-        while (k) {
-            __m256i src = _mm256_loadu_si256((__m256i const*) p);
-            __m256i t;
-
-            t = _mm256_unpacklo_epi8(src, zero);
-            s0 = _mm256_adds_epu16(s0, t);
-            t = _mm256_unpackhi_epi8(src, zero);
-            s1 = _mm256_adds_epu16(s1, t);
-            p += sizeof(src);
-            k--;
-        }
-
-        // LOW - combine S0 and S1 into sum0
-        t0 = _mm256_unpacklo_epi16(s0, zero);
-        sum0 = _mm256_add_epi32(sum0, t0);
-        t1 = _mm256_unpacklo_epi16(s1, zero);
-        sum1 = _mm256_add_epi32(sum1, t1);
-
-        // HIGH - combine S0 and S1 into sum1
-        t0 = _mm256_unpackhi_epi16(s0, zero);
-        sum0 = _mm256_add_epi32(sum0, t0);
-        t1 = _mm256_unpackhi_epi16(s1, zero);
-        sum1 = _mm256_add_epi32(sum1, t1);
-    }
-    // here we must sum the 4-32 bit sums into one 32 bit sum
-    _mm256_store_si256((__m256i*)s, sum0);
-    sum2 = (s[0]<<8) + s[1] + (s[2]<<8) + s[3] + (s[4]<<8) + s[5] + (s[6]<<8) + s[7];
-    _mm256_store_si256((__m256i*)s, sum1);
-    sum2 += (s[0]<<8) + s[1] + (s[2]<<8) + s[3] + (s[4]<<8) + s[5] + (s[6]<<8) + s[7];
-
-    return sum2;
-}
-
-uint16_t cksum_avx2(unsigned char *p, size_t n, uint32_t initial)
-{
-    uint32_t sum = ntohs(initial);
-
-    if (n < 128) { return cksum_generic(p, n, initial); }
-    if (n >= 64) {
-        size_t k = (n >> 5);
-        sum += cksum_avx2_loop(p, k);
-        n -= (32*k);
-        p += (32*k);
-    }
-    if (n > 1) {
-        size_t k = (n>>1);   // number of 16-bit words
-        sum += cksum_ua_loop(p, k);
-        n -= (2*k);
-        p += (2*k);
-    }
-    if (n)       // take care of left over byte
-        sum += (p[0] << 8);
-    while(sum>>16)
-        sum = (sum & 0xFFFF) + (sum>>16);
-    return (uint16_t)~sum;
 }
 
 // Incrementally update checksum when modifying a 16-bit value.

--- a/src/lib/checksum_lib.h
+++ b/src/lib/checksum_lib.h
@@ -1,0 +1,22 @@
+/*
+ * Checksum library routines that are inline functions.
+ * For inclusion by checksum implementations.
+ */
+//
+// A unaligned version of the cksum,
+// n is number of 16-bit values to sum over, n in it self is a
+// 16 bit number in order to avoid overflow in the loop
+//
+static inline uint32_t cksum_ua_loop(unsigned char *p, uint16_t n)
+{
+  uint32_t s0 = 0;
+  uint32_t s1 = 0;
+
+  while (n) {
+    s0 += p[0];
+    s1 += p[1];
+    p += 2;
+    n--;
+  }
+  return (s0<<8)+s1;
+}


### PR DESCRIPTION
The Makefile treats these files specially: avx2.c compiles with -mavx2 and sse2.c with -msse2. This solves two problems.

First problem: The SSE2 code was actually compiling with AVX instructions because of '-mavx2'. This would cause a crash on hardware that does not support AVX or AVX2 such as an Atom CPU. (We missed this testing on the Sandy Bridge lab servers because they do support AVX even though they do not support AVX2.) Caught by Justin Cormack: https://groups.google.com/d/msg/snabb-devel/I_3dJvfl7gY/YHgHVzjMq0kJ

Second problem: The Makefile had overlapping rules for building the SIMD code and this causes warnings to be printed. That is because the default build rule applied to these files but then we also had specific rules. This is solved now because the arch/ directory is excluded from the default rules.