### PR TITLE
Fix a couple of bugs that can affect the packet filter

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ E= @echo
 # Defined here to detect version mismatches at build time.
 LUAJIT_VSN    := "v2.0.3-328-g04dc64b"
 LJSYSCALL_VSN := "v0.10-65-g7081d97"
-PFLUA_VSN     := "af132e77feede98dce0f2efcdc8dd9206a28c2e3"
+PFLUA_VSN     := "13b194e7a214faae5c3d2916a998418fc841dbc2"
 
 TEST_SKIPPED="43"
 

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -54,7 +54,7 @@ maxsleep = 100
 -- Can be used to drive timers in apps.
 monotonic_now = false
 function now ()
-   return monotonic_now
+   return monotonic_now or C.get_monotonic_time()
 end
 
 -- Run app:methodname() in protected mode (pcall). If it throws an


### PR DESCRIPTION
This branch contains fixes to the packet filter:

- Fix bug in `engine.now()` that can return false when called before any breathe loop (happens when the initial app networks contains a stateful filter).
- Pulled in a fix for Igalia/pflua#178.
