### PR TITLE
Fix problem where engine.now() could return false

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -54,7 +54,7 @@ maxsleep = 100
 -- Can be used to drive timers in apps.
 monotonic_now = false
 function now ()
-   return monotonic_now
+   return monotonic_now or C.get_monotonic_time()
 end
 
 -- Run app:methodname() in protected mode (pcall). If it throws an


### PR DESCRIPTION
engine.now() could return false if an app asked for the time before the breathe loop has run. This could happen when an app accesses engine.now during initialization. This indeed does happen if the initial app network uses a stateful PcapFilter.