### PR TITLE
[draft] Create new 'snabb' module to define the core API

### DIFF
--- a/src/program/spray/README.inc
+++ b/src/program/spray/README.inc
@@ -1,0 +1,4 @@
+Usage: spray <inputfile> <outputfile>
+
+Read packets from the input file, drop every second one, then write
+the rest to the output file. Both files are in pcap format.

--- a/src/program/spray/spray.lua
+++ b/src/program/spray/spray.lua
@@ -11,19 +11,19 @@ end
 local inputfile, outputfile = unpack(arg)
 
 -- Setup
-local config = snabb.config()
-config:set_app('reader', 'pcap_reader', inputfile)
-config:set_app('sprayer', 'sprayer')
-config:set_app('writer',  'pcap_writer', outputfile)
-config:set_link('reader.output -> sprayer.input')
-config:set_link('sprayer.output -> writer.input')
+local conf = snabb.config()
+conf:config_set_app('reader', 'pcap_reader', inputfile)
+conf:config_set_app('sprayer', 'sprayer')
+conf:config_set_app('writer',  'pcap_writer', outputfile)
+conf:config_set_link('reader.output -> sprayer.input')
+conf:config_set_link('sprayer.output -> writer.input')
 
 -- Execute
 local engine = snabb.engine()
-engine:configure(config)
+engine:engine_configure(config)
 print(("Spraying packets from %s to %s"):format(inputfile, outputfile))
-engine:run({duration = 'toidle'})
+engine:engine_run({duration = 'toidle'})
 
 -- Report
-print(("Processed %d packets"):format(engine:packet()))
+print(("Processed %d packets"):format(engine:engine_processed_packets()))
 

--- a/src/program/spray/spray.lua
+++ b/src/program/spray/spray.lua
@@ -1,0 +1,29 @@
+-- spray: program to replay a trace and add packet loss
+
+local snabb = require("snabb1") -- Use API version 1
+
+-- Check command line
+if #arg ~= 2 then
+   print(require("program.spray.README_inc"))
+   os.exit(0)
+end
+
+local inputfile, outputfile = unpack(arg)
+
+-- Setup
+local config = snabb.config()
+config:set_app('reader', 'pcap_reader', inputfile)
+config:set_app('sprayer', 'sprayer')
+config:set_app('writer',  'pcap_writer', outputfile)
+config:set_link('reader.output -> sprayer.input')
+config:set_link('sprayer.output -> writer.input')
+
+-- Execute
+local engine = snabb.engine()
+engine:configure(config)
+print(("Spraying packets from %s to %s"):format(inputfile, outputfile))
+engine:run({duration = 'toidle'})
+
+-- Report
+print(("Processed %d packets"):format(engine:packet()))
+

--- a/src/program/spray/sprayer.lua
+++ b/src/program/spray/sprayer.lua
@@ -1,0 +1,33 @@
+-- sprayer: app that drops every second packet
+--
+--         +---------+
+--         |         |
+-- input-->+ sprayer +-->output
+--         |         |
+--         +---------+
+
+local snabb = require("snabb1") -- Use API version 1
+
+-- Return alternating true, false, true, false, ...
+local toggleflag = false
+local function toggle ()
+   toggle = not toggle
+   return toggle
+end
+   
+-- Run the sprayer app forwarding logic.
+function push ()
+   local input = inputs.input
+   local output = outputs.output
+   while not input:link_is_empty() do
+      local packet = input:link_receive()
+      if toggle() then
+         -- Forward the packet
+         output:link_transmit(packet)
+      else
+         -- Drop the packet
+         packet:packet_free()
+      end
+   end
+end
+

--- a/src/program/spray/sprayer.lua
+++ b/src/program/spray/sprayer.lua
@@ -19,14 +19,14 @@ end
 function push ()
    local input = inputs.input
    local output = outputs.output
-   while not input:link_is_empty() do
-      local packet = input:link_receive()
+   while not input:is_empty() do
+      local packet = input:receive()
       if toggle() then
          -- Forward the packet
-         output:link_transmit(packet)
+         output:transmit(packet)
       else
          -- Drop the packet
-         packet:packet_free()
+         packet:free()
       end
    end
 end

--- a/src/program/spray/sprayer.lua
+++ b/src/program/spray/sprayer.lua
@@ -19,14 +19,14 @@ end
 function push ()
    local input = inputs.input
    local output = outputs.output
-   while not input:is_empty() do
-      local packet = input:receive()
+   while not input:link_is_empty() do
+      local packet = input:link_receive()
       if toggle() then
          -- Forward the packet
-         output:transmit(packet)
+         output:link_transmit(packet)
       else
          -- Drop the packet
-         packet:free()
+         packet:packet_free()
       end
    end
 end

--- a/src/snabb.lua
+++ b/src/snabb.lua
@@ -1,0 +1,107 @@
+-- snabb.lua: Snabb Switch core API
+
+-- This module provides the complete Snabb Switch API.
+--
+-- Consolidating the whole API into a module has these benefits:
+--
+-- * Single source for reference, making updates, checking for changes.
+-- * Multiple API versions could co-exist (e.g. snabb, snabb2, snabb3).
+-- * Gives control over when/how changes are exposed to users.
+
+-- The API is defined by the items in this table.
+local snabb = { api_verison = '1.0' }
+
+local engine = require("core.app")
+local packet = require("core.packet")
+local link   = require("core.link")
+local config = require("core.config")
+
+--------------------------------------------------------------
+-- Engine API
+--------------------------------------------------------------
+
+snabb.engine = {}
+
+-- snabb.engine.run()
+snabb.engine.run = engine.run
+
+--------------------------------------------------------------
+-- Packet API
+--------------------------------------------------------------
+
+-- snabb.packet() => packet
+--   Return a new empty packet object.
+function snabb.packet ()
+   return packet.allocate()
+end
+
+-- Methods for packet objects:
+
+local packetmethods = {
+
+   -- packet:length() = number
+   --   Return the packet data length.
+   length = packet.length,
+
+   -- packet:clone() => packet
+   --   Return a new copy of the packet.
+   clone = packet.clone,
+
+   -- packet:append(pointer, length)
+   --   Append the LEGNTH bytes at POINTER to the end the packet.
+   append = packet.append,
+
+   -- packet:prepend(pointer, length)
+   --   Prepend the LENGTH bytes at POINTER to the start of the packet.
+   prepend = packet.prepend,
+
+   -- packet:shiftleft(bytes)
+   --   Move the packet data to the left by BYTES.
+   shiftleft = packet.shiftleft,
+}
+
+-- Make the packet methods available on 'struct packet' objects
+ffi.metatable('struct packet', {__index = packetmethods})
+
+--------------------------------------------------------------
+-- Config API
+--------------------------------------------------------------
+
+local configmethods
+
+-- snabb.config()
+--   Return a new empty config object.
+function snabb.config ()
+   return setmetatable(config.new(), {__index = configmethods})
+end
+
+configmethods = {
+
+   -- config:set_app(name, class, config)
+   --   Define a new app in the config. If an app called NAME already
+   --   exists then it is replaced.
+   set_app = config.app,
+
+   -- config:set_link(spec)
+   --   Define a unidirectional link between named ports of apps.
+   --
+   --   SPEC is a string with the format is APP1.PORT1->APP2.PORT2.
+   --   For example, "filter.input->filter.output".
+   --
+   --   The named apps must already exist and have the required ports.
+   --   If either of the ports is already connected with a link then
+   --   that is replaced by the new link. (Each port can be connected
+   --   only once.)
+   set_link = config.link,
+
+   -- ...
+}
+
+--------------------------------------------------------------
+-- Link API
+--------------------------------------------------------------
+
+-- ...
+
+return snabb
+


### PR DESCRIPTION
The idea is to explicitly define our core API in one place.  Then users will not required a lot of individual modules (core.packet, core.link, etc) but instead access everything through a unified and well-defined module (snabb).

This draft API would make code look more like this:

    local config = snabb.config()
    config:add_app(...)
    config:add_link(...)
    snabb.engine.configure(config)

and

    local packet = snabb.packet()
    packet:shiftleft(42)
    print("packet length after shortening: " .. packet:length())

Notably you would not have to require() any modules anymore. (You could require("snabb") if you want to but we could probably just make it global.)

This MIGHT also make it easier to create new versions of the API with semantic versioning (http://semver.org/) and even to allow apps to say which API version they depend on so that we could keep compatibility with older versions for as long as we want.