### PR TITLE
core: Use the array part of app.input and app.output tables

### DIFF
--- a/src/README.md.src
+++ b/src/README.md.src
@@ -105,13 +105,6 @@ For example: Move packets from input ports to output ports or to a
 network adapter.
 
 
-— Method **myapp:relink**
-
-*Optional*. React to a changes in input/output links (`app.input` and
-`app.output`). This method is called after a link reconfiguration but
-before the next packets are processed.
-
-
 — Method **myapp:reconfig** *arg*
 
 *Optional*. Reconfigure the app with a new *arg*. If this method is not

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -201,13 +201,12 @@ function apply_config_actions (actions, conf)
       link.receiving_app = app_name_to_index[ta]
       -- Add link to apps
       new_app_table[fa].output[fl] = link
+      table.insert(new_app_table[fa].output, link)
       new_app_table[ta].input[tl] = link
+      table.insert(new_app_table[ta].input, link)
       -- Remember link
       new_link_table[linkspec] = link
       table.insert(new_link_array, link)
-   end
-   for _, app in ipairs(new_app_array) do
-      if app.relink then app:relink() end
    end
    -- commit changes
    app_table, link_table = new_app_table, new_link_table

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -109,14 +109,14 @@ function get_sf_devices()
    return sf_devices
 end
 
-Source = setmetatable({zone = "Source"}, {__index = basic_apps.Basic});
+Source = {}
 
 function Source:new(size)
    return setmetatable({}, {__index=Source})
 end
 
 function Source:pull()
-   for _, o in ipairs(self.outputi) do
+   for _, o in ipairs(self.output) do
       for i = 1, link.nwritable(o) do
          local p = packet.allocate()
          ffi.copy(p.data, self.to_mac_address, 6)


### PR DESCRIPTION
Previously the links for apps were accessible only by name
e.g. input.rx or output.tx. Now they are available both by name and by
number e.g. input[1] or output[2]. The exact order is not fixed.

This makes it easy to write apps that don't care what their links are
called. If there is only one link then it can be accessed as input[1].
If there are many links they can be accessed with an ipairs() loop.

The relink() method of apps is also removed. The only way that it was
actually used was to emulate this behavior in a more complex way. That
code is also removed now from basic_apps and snabbmark.

This may resolve the question: what should an app name its input and
output links in cases where it does not actually matter? Now instead
of having to choose an arbitrary name like 'rx' or 'input' or 'left'
or 'west' the app can simply say that it requires one link and then
access that by number.

So code like this:

    local rx = input.rx
    assert(rx, "rx link not connected")

could instead be written as:

    assert(#input == 1, "one input link expected")
    local rx = input[1]

which would be backwards compatible and allow the link to have any
name. That would solve the existing problem of apps expecting
inconsistent names.

(This does not apply to cases where apps actually need to have
multiple links that are distinguished by their names e.g. a tunnel app
that will encapsulate packets from one input and decapsulate those
from another.)