### PR TITLE
[draft] Sandbox level 2: one LuaState VM for each app

### DIFF
--- a/src/apps/basic/basic.lua
+++ b/src/apps/basic/basic.lua
@@ -1,0 +1,12 @@
+
+inputi, outputi = {}, {}
+
+function relink()
+   inputi, outputi = {}, {}
+   for _, l in pairs(output) do
+      table.insert(outputi, l)
+   end
+   for _, l in pairs(input) do
+      table.insert(inputi, l)
+   end
+end

--- a/src/apps/basic/sink.lua
+++ b/src/apps/basic/sink.lua
@@ -1,0 +1,11 @@
+require ('apps.basic.basic')
+
+
+function push()
+   for _, i in ipairs(inputi) do
+      for _ = 1, link.nreadable(i) do
+         local p = link.receive(i)
+         packet.free(p)
+      end
+   end
+end

--- a/src/apps/basic/source.lua
+++ b/src/apps/basic/source.lua
@@ -1,0 +1,17 @@
+require ('apps.basic.basic')
+
+local size = size or 60
+local pkt = packet.from_pointer (ffi.new("char[?]", size), size)
+
+function pull()
+   for _, o in ipairs(outputi) do
+      for i = 1, link.nwritable(o) do
+         link.transmit(o, packet.clone(pkt))
+      end
+   end
+end
+
+
+function stop()
+   packet.free(pkt)
+end

--- a/src/apps/basic/test.lua
+++ b/src/apps/basic/test.lua
@@ -1,0 +1,12 @@
+module(..., package.seeall)
+
+function selftest()
+   local c = config.new()
+   config.app(c, 'source', 'apps.basic.source', {size=120})
+   config.app(c, 'sink', 'apps.basic.sink')
+   config.link(c, 'source.output -> sink.input')
+   engine.configure(c)
+
+   engine.main{duration=0.1, report={showlinks=true}}
+   engine.closeapps()
+end

--- a/src/apps/basic/test.lua
+++ b/src/apps/basic/test.lua
@@ -7,6 +7,6 @@ function selftest()
    config.link(c, 'source.output -> sink.input')
    engine.configure(c)
 
-   engine.main{duration=0.1, report={showlinks=true}}
+   engine.main{duration=1, report={showlinks=true}}
    engine.closeapps()
 end

--- a/src/apps/keyed_ipv6_tunnel/test.lua
+++ b/src/apps/keyed_ipv6_tunnel/test.lua
@@ -1,0 +1,58 @@
+module(..., package.seeall)
+local app = require("core.app")
+local pcap = require("apps.pcap.pcap")
+
+
+function selftest ()
+   print("Keyed IPv6 tunnel selftest")
+   local ok = true
+
+   local input_file = "apps/keyed_ipv6_tunnel/selftest.cap.input"
+   local output_file = "apps/keyed_ipv6_tunnel/selftest.cap.output"
+   local tunnel_config = {
+      local_address = "00::2:1",
+      remote_address = "00::2:1",
+      local_cookie = "12345678",
+      remote_cookie = "12345678",
+      default_gateway_MAC = "a1:b2:c3:d4:e5:f6"
+   } -- should be symmetric for local "loop-back" test
+
+   local c = config.new()
+   config.app(c, "source", pcap.PcapReader, input_file)
+   config.app(c, "tunnel", 'apps.keyed_ipv6_tunnel.tunnel', tunnel_config)
+   config.app(c, "sink", pcap.PcapWriter, output_file)
+   config.link(c, "source.output -> tunnel.decapsulated")
+   config.link(c, "tunnel.encapsulated -> tunnel.encapsulated")
+   config.link(c, "tunnel.decapsulated -> sink.input")
+   app.configure(c)
+
+   app.main({duration = 0.25}) -- should be long enough...
+   -- Check results
+   if io.open(input_file):read('*a') ~=
+      io.open(output_file):read('*a')
+   then
+      print ('bad compare')
+      ok = false
+   end
+
+   app.configure (config.new())
+
+   local c = config.new()
+   config.app(c, "source", 'apps.basic.source')
+   config.app(c, "tunnel", 'apps.keyed_ipv6_tunnel.tunnel', tunnel_config)
+   config.app(c, "sink", 'apps.basic.sink')
+   config.link(c, "source.output -> tunnel.decapsulated")
+   config.link(c, "tunnel.encapsulated -> tunnel.encapsulated")
+   config.link(c, "tunnel.decapsulated -> sink.input")
+   app.configure(c)
+
+   print("run simple one second benchmark ...")
+   app.main{duration = 1, report={showlinks=true}}
+
+   if not ok then
+      print("selftest failed")
+      os.exit(1)
+   end
+   print("selftest passed")
+
+end

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -97,7 +97,7 @@ function restart_dead_apps ()
 end
 
 -- Configure the running app network to match new_configuration.
--- 
+--
 -- Successive calls to configure() will migrate from the old to the
 -- new app network by making the changes needed.
 function configure (new_config)
@@ -186,7 +186,7 @@ function apply_config_actions (actions, conf)
    for _, action in ipairs({'stop', 'restart', 'keep', 'reconfig', 'start'}) do
       for _, name in ipairs(actions[action]) do
 	 if log and action ~= 'keep' then
-            io.write("engine: ", action, " app ", name, "\n") 
+            io.write("engine: ", action, " app ", name, "\n")
          end
 	 ops[action](name)
       end
@@ -230,6 +230,12 @@ function main (options)
       pace_breathing()
    until done and done()
    if not options.no_report then report(options.report) end
+end
+
+function closeapps()
+   for name, app in pairs(app_table) do
+      if app.stop then app:stop() end
+   end
 end
 
 local nextbreath

--- a/src/core/app_loader.lua
+++ b/src/core/app_loader.lua
@@ -1,0 +1,155 @@
+
+local statebox = require ('lib.lua.statebox')
+
+
+-- to wrap pcall()-like functions
+-- with return form (bool, ...)
+local function stripassert(ok, ...)
+   return select(2, assert(ok, ...))
+end
+
+
+-- shallow table copy
+local function copy(dst, src, ...)
+   if not src then return dst end
+   for k, v in pairs(src) do
+      dst[k] = v
+   end
+   return copy(dst, ...)
+end
+
+
+-- returns an array of all global function names in appbox
+local function get_global_functions(appbox)
+   return stripassert(appbox:load[[
+      local o = {}
+      for k, v in pairs(_G) do
+         if type(v) == 'function' then
+            o[#o+1] = k
+         end
+      end
+      return o
+   ]]:pcall())
+end
+
+
+-- returns a table with the global values of the given names
+local function pull_known_names(appbox, ...)
+   return stripassert(appbox:load[[
+      local o = {}
+      for i = 1, select('#', ...) do
+         local name = select(i, ...)
+         o[name] = _G[name]
+      end
+      return o
+   ]]:pcall(nil, ...))
+end
+
+
+-- creates the LuaState sandbox
+-- and loads with the SnS app
+-- returns a Lua table with a proxy for
+-- each global function and some values (name, zone)
+-- defined in the app
+function new_app(class, args)
+   local appbox = assert(statebox[[
+      -- minimal libraries
+      ffi = require ('ffi')
+      engine = require ('core.app')
+      packet = require ('core.packet')
+      link = require ('core.link')
+
+      -- sets a table of FFI objects
+      -- used for injecting in/out links
+      local prevcts = {}
+      function setffitable(name, ct, t)
+         if not t then return end
+         if ct and type(ct) == 'string' then
+            prevcts[ct] = prevcts[ct] or ffi.typeof(ct)
+            ct = prevcts[ct]
+         end
+         local o = _G[name] or {}
+         for k,v in pairs(t) do
+            if ct and type(v) == 'userdata' then
+               v = ffi.cast(ct, v)
+            end
+            o[k] = v
+         end
+         _G[name] = o
+      end
+
+      -- loads the app within the sandbox
+      -- appname is the dotted name, loaded with require()
+      -- args will be copied to _G
+      -- profilemod (optional) like '-jp=...' commandline parameter
+      function loadapp(appname, args, profilemode)
+         if args then
+            for k, v in pairs(args) do
+               _G[k] = v
+            end
+         end
+         if profilemode then
+            require("jit.p").start(profilemode)
+         end
+         require (appname)
+         if profilemode then
+            local prevstop = stop
+            stop = function ()
+               if prevstop then prevstop() end
+               print ('profile: ', appname)
+               require('jit.p').stop()
+            end
+         end
+      end
+   ]])
+
+   -- loads initial chunk and app
+   assert(appbox:pcall())
+   local prevglobals = get_global_functions(appbox)
+   assert(appbox:pcall('loadapp', class.appname, args, '4vl'))
+
+   -- set proxy values
+   local app = copy({
+      name = class.appname,
+      zone = class.appname,
+      appbox = appbox,
+   }, pull_known_names(appbox, 'name', 'zone'))
+
+   -- set proxy functions
+   for _, fname in ipairs(prevglobals) do
+      prevglobals[fname] = true
+   end
+   for _, fname in ipairs(get_global_functions(appbox)) do
+      if not prevglobals[fname] then
+         app[fname] = function(self, ...)
+            return stripassert(self.appbox:pcall(fname, ...))
+         end
+      end
+   end
+
+   -- use the relink function to inject links into the sandbox
+   local prevrelink = app.relink
+   app.relink = function(self)
+      self.appbox:pcall('setffitable', 'input', 'struct link *', self.input)
+      self.appbox:pcall('setffitable', 'output', 'struct link *', self.output)
+      if prevrelink then
+         return prevrelink(self)
+      end
+   end
+
+   return app
+end
+
+
+-- main entry point
+-- the 'class' is just something to call :new() on
+function make_app_class(appname)
+   return {
+      appname = appname,
+      new = new_app,
+   }
+end
+
+
+-- return the loader function
+return make_app_class

--- a/src/core/config.lua
+++ b/src/core/config.lua
@@ -3,6 +3,7 @@
 module(..., package.seeall)
 
 local lib = require("core.lib")
+local load_app = require('core.app_loader')
 
 -- API: Create a new configuration.
 -- Initially there are no apps or links.
@@ -23,9 +24,12 @@ end
 --
 -- Example: config.app(c, "nic", Intel82599, {pciaddr = "0000:00:01.00"})
 function app (config, name, class, arg)
-   arg = arg or "nil"
+--    arg = arg or "nil"
    assert(type(name) == "string", "name must be a string")
-   assert(type(class) == "table", "class must be a table")
+   if type(class) == 'string' then
+      class = assert(load_app(class))
+   end
+   assert(type(class) == "table", ("class %q must be a table, got [%s]"):format(name, tostring(class)))
    config.apps[name] = { class = class, arg = arg}
 end
 

--- a/src/core/freelist.lua
+++ b/src/core/freelist.lua
@@ -3,10 +3,13 @@ module(...,package.seeall)
 local ffi = require("ffi")
 
 function new (type, size)
-   return { nfree = 0,
-            max = size,
-            -- XXX Better LuaJIT idiom for specifying the array type?
-            list = ffi.new(type.."[?]", size) }
+   local typ = ffi.typeof([[
+      struct {
+         int nfree, max;
+         $ list[?];
+      }
+   ]], ffi.typeof(type))
+   return typ(size, {nfree=0, max=size})
 end
 
 function add (freelist, element)

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -22,7 +22,11 @@ local max_payload = tonumber(C.PACKET_PAYLOAD_SIZE)
 local max_packets = 1e5
 local packet_allocation_step = 1000
 local packets_allocated = 0
-local packets_fl = freelist.new("struct packet *", max_packets)
+local packets_fl = nil
+
+function init()
+   packets_fl = packets_fl or freelist.new("struct packet *", max_packets, 'packets_fl')
+end
 
 -- Return an empty packet.
 function allocate ()
@@ -79,7 +83,7 @@ function from_string (d)         return from_pointer(d, #d) end
 local function free_internal (p)
    p.length = 0
    freelist_add(packets_fl, p)
-end   
+end
 
 function free (p)
    engine.frees = engine.frees + 1

--- a/src/lib/lua/statebox.lua
+++ b/src/lib/lua/statebox.lua
@@ -1,0 +1,256 @@
+local ffi = require('ffi')
+local C = ffi.C
+
+ffi.cdef [[
+   /*
+    * copied from lua.h
+    */
+
+   typedef struct lua_State lua_State;
+   typedef void * (*lua_Alloc) (void *ud, void *ptr, size_t osize, size_t nsize);
+   typedef double lua_Number;
+
+   static const int LUA_GLOBALSINDEX = (-10002);
+   static const int LUA_MULTRET = (-1);
+
+   // basic types
+   enum {
+      LUA_TNONE = (-1),
+      LUA_TNIL,
+      LUA_TBOOLEAN,
+      LUA_TLIGHTUSERDATA,
+      LUA_TNUMBER,
+      LUA_TSTRING,
+      LUA_TTABLE,
+      LUA_TFUNCTION,
+      LUA_TUSERDATA,
+      LUA_TTHREAD,
+   };
+
+   // thread status; 0 is OK
+   enum {
+      LUA_YIELD = 1,
+      LUA_ERRRUN,
+      LUA_ERRSYNTAX,
+      LUA_ERRMEM,
+      LUA_ERRERR,
+   };
+
+   void lua_close (lua_State *L);
+   void lua_createtable (lua_State *L, int narr, int nrec);
+   void lua_getfield (lua_State *L, int index, const char *k);
+   int lua_gettop (lua_State *L);
+   int lua_next (lua_State *L, int index);
+   int lua_pcall (lua_State *L, int nargs, int nresults, int errfunc);
+   void lua_pushboolean (lua_State *L, int b);
+   void lua_pushlightuserdata (lua_State *L, void *p);
+   void lua_pushlstring (lua_State *L, const char *s, size_t len);
+   void lua_pushnil (lua_State *L);
+   void lua_pushnumber (lua_State *L, lua_Number n);
+   int lua_resume (lua_State *L, int narg);
+   void lua_settable (lua_State *L, int index);
+   void lua_settop (lua_State *L, int index);
+   int lua_status (lua_State *L);
+   int lua_toboolean (lua_State *L, int index);
+   const char *lua_tolstring (lua_State *L, int index, size_t *len);
+   lua_Number lua_tonumber (lua_State *L, int index);
+   int lua_type (lua_State *L, int index);
+
+   int luaL_loadbuffer (lua_State *L, const char *buff, size_t sz, const char *name);
+   lua_State *luaL_newstate (void);
+   void luaL_openlibs (lua_State *L);
+]]
+
+
+ffi.cdef [[
+   // our sandbox structure.  currently it's just a Lua State
+   struct statebox {
+      lua_State *L;
+   };
+]]
+
+local statebox = {}
+statebox.__index = statebox
+
+local statebox_t = ffi.typeof('struct statebox')
+
+-- pushes several values into the given LuaState stack
+-- handles only symple values: nil, boolean, numbers (double floats),
+-- strings, tables (only key/values of known types), userdata and
+-- cdata, which are pushed as lightuserdata values
+local function push_values(L, ...)
+   local narg = select('#', ...)
+   local prevtop = C.lua_gettop(L)
+   for i = 1, narg do
+      local v = select(i, ...)
+      local typ = type(v)
+      if typ == 'nil' then
+         C.lua_pushnil(L)
+      elseif typ == 'boolean' then
+         C.lua_pushboolean(L, v)
+      elseif typ == 'number' then
+         C.lua_pushnumber(L, v)
+      elseif typ == 'string' then
+         C.lua_pushlstring(L, v, #v)
+      elseif typ == 'table' then
+         C.lua_createtable(L, 0, 0)
+         for k1, v1 in pairs(v) do
+            push_values(L, k1, v1)
+            C.lua_settable(L, -3)
+         end
+      elseif typ == 'userdata' or typ == 'cdata' then
+         C.lua_pushlightuserdata(L, v)
+      end
+   end
+
+   return C.lua_gettop(L) - prevtop
+end
+
+-- returns a variable number of values from the stack
+-- of a Lua State, optinally pops those values.
+-- L : Lua State we want to read
+-- num (optional): number of values to read.  defaults to all values
+-- keep (optional): boolean flag, if true, keeps the values in the stack
+--  if false, removes the values it reads.
+local pv_sz = ffi.new('size_t[?]', 1)
+local function pull_values(L, num, keep)
+   local narg = C.lua_gettop(L)
+   num = num or narg
+   local o = {}
+   for i = narg-num+1, narg do
+      local typ, v = C.lua_type(L, i), nil
+      if typ == C.LUA_TNIL then
+         v = nil
+      elseif typ == C.LUA_TBOOLEAN then
+         v = C.lua_toboolean(L, i) ~= 0
+      elseif typ == C.LUA_TNUMBER then
+         v = C.lua_tonumber(L, i)
+      elseif typ == C.LUA_TSTRING then
+         local buf = C.lua_tolstring(L, i, pv_sz)
+         v = ffi.string(buf, pv_sz[0])
+      elseif typ == C.LUA_TTABLE then
+         v = {}
+         C.lua_pushnil(L)
+         while C.lua_next(L, i) ~= 0 do
+            local k1, v1 = pull_values(L, 2, true)
+            v[k1] = v1
+            C.lua_settop(L, -2)
+         end
+      end
+      o[i-narg+num] = v
+   end
+   if not keep then
+      C.lua_settop(L, narg-num)
+   end
+   return unpack(o)
+end
+
+-- FFI object constructor.
+-- creates the Lua State and loads standard libraries.
+-- optionally compiles the given Lua code chunk and
+-- leaves the resultant function in the stack.
+function statebox:__new(code)
+   local box = ffi.new(statebox_t)
+   return assert(box:init():load(code, '[startcode]'))
+end
+
+-- object initializer
+-- creates the Lua State and loads standard libraries.
+-- signals an error on failure to create the State
+function statebox:init()
+   if self.L ~= nil then return self end
+
+   self.L = C.luaL_newstate()
+   assert(self.L ~= nil, "Couldn't allocate new LuaState")
+
+   C.luaL_openlibs(self.L)
+   return self
+end
+
+-- compiles a chunk of code and leaves the resultant function in the stack.
+-- returns self or false and an error message
+function statebox:load(code, name)
+   if self.L == nil then return false, "Can't load code on a closed statebox" end
+   if not code then return self end
+
+   if C.luaL_loadbuffer(self.L, code, #code, name) ~= 0 then
+      local err = ffi.string(C.lua_tolstring(self.L, -1, nil))
+      self:close()
+      return false, "Error loading startcode: "..tostring(err)
+   end
+
+   return self
+end
+
+-- calls a function in the Lua State.
+-- the first argument should be either:
+--   - the name of a function in the global environment
+--   - nil to call a function in the top of the stack
+-- the rest of the arguments are sent to the function
+-- according to the limitations of push_values().
+-- returns (true, result values) if successful or
+-- (false, error) if any error is raised (similar to standard pcall())
+function statebox:pcall(fname, ...)
+   if self.L == nil then return false, "Can't call closed statebox" end
+
+   if fname ~= nil then
+      C.lua_getfield(self.L, C.LUA_GLOBALSINDEX, fname)
+   end
+
+   local nargs, err = push_values(self.L, ...)
+   if not nargs then return nargs, err end
+
+   if C.lua_pcall(self.L, nargs, C.LUA_MULTRET, 0) ~= 0 then
+      local err = ffi.string(C.lua_tolstring(self.L, -1, nil))
+      C.lua_settop(self.L, 0)
+      return false, err
+   end
+
+   return true, pull_values(self.L)
+end
+
+-- resumes the Lua State as a coroutine.
+-- if there's a function in the top of the stack it's popped
+-- and called with the given parameters (like :pcall(nil, ...))
+-- if it finishes successfully or calls coroutine.yield(),
+-- this will return (true, result values).
+-- if the state has yield()ed, subsequent resume() calls will
+-- continue the coroutine operation.
+-- if the coroutine has finished or raised an error, it will
+-- be an error to call :resume() again.
+-- returns (false, error) on any failure
+function statebox:resume(...)
+   if self.L == nil then return false, "Can't resume closed statebox" end
+
+   if C.lua_status(self.L) ~= 1 and C.lua_type(self.L, -1) ~= C.LUA_TFUNCTION then
+      return false, "Need a function or suspended thread"
+   end
+
+   local nargs, err = push_values(self.L, ...)
+   if not nargs then return nargs, err end
+
+   local ret = C.lua_resume(self.L, nargs)
+   if ret == 0 or ret == C.LUA_YIELD then
+      return true, pull_values(self.L)
+   end
+   return false, ffi.string(C.lua_tolstring(self.L, -1, nil))
+end
+
+-- disposes the Lua state.
+-- calling :init() again can reopen the box
+function statebox:close()
+   if self.L ~= nil then
+      C.lua_close(self.L)
+      self.L = nil
+   end
+end
+
+-- garbage collection hook
+function statebox:__gc()
+   self:close()
+end
+
+-- returns the type as the whole module,
+-- can be used as FFI type and constructor
+ffi.metatype(statebox_t, statebox)
+return statebox_t


### PR DESCRIPTION
`lib.lua.statebox` implements the LuaState handling code using FFI calls to the Lua C API.  Handles passing simple values and non-recursive tables. Any userdata or FFI cdata value is cast into a lightuserdata.

`core.app_loader` uses `lib.lua.statebox` to create app-compatible objects.
`core.config` calls this loader when the app is specified with a dotted.name instead of the usual class table.

Translated `apps.basic.source`/`sink` to the new style.  It's very similar to the sandbox level 1 style, but now it's safe to call `require()` to reuse code within the app.  Usually there's no need to call `module()`, since we do want most of the code and variables to be 'global' within the sandbox.  Global functions and some variable names (currently zone and name) are copied to the app proxy object.

The start code within the sandbox sets the LuaJIT profiler, probably the `app:stop()` hook is not the right place to close it.

__Note__: the sample apps seem to be an order of magnitude slower than previously and dies if the `engine.main()` lasts more than 400msec.  Profiling within the sandbox shows almost all the time is spent allocating packets, and dies around 100k allocations.  I think the freelist object, being a Lua object, doesn't like the sandbox.  Should we somehow force all the freelist/allocation to happen in the main thread?  or simply turning the freelist into an FFI object (which is a trivial change) would help to make it VM-agnostic and shareable, just like links?