### PR TITLE
memory: Force the kernel to enable working HugeTLB allocation

### DIFF
--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -108,7 +108,7 @@ end
 
 function selftest (options)
    print("selftest: memory")
-   print("HugeTLB pages (/proc/sys/vm/nr_hugepages): " .. get_hugepages())
+   print("Kernel vm.nr_hugepages: " .. syscall.sysctl("vm.nr_hugepages"))
    for i = 1, 4 do
       io.write("  Allocating a "..(huge_page_size/1024/1024).."MB HugeTLB: ")
       io.flush()
@@ -119,7 +119,7 @@ function selftest (options)
       ffi.cast("uint32_t*", dmaptr)[0] = 0xdeadbeef -- try a write
       assert(dmaptr ~= nil and dmalen == huge_page_size)
    end
-   print("HugeTLB pages (/proc/sys/vm/nr_hugepages): " .. get_hugepages())
+   print("Kernel vm.nr_hugepages: " .. syscall.sysctl("vm.nr_hugepages"))
    print("HugeTLB page allocation OK.")
 end
 


### PR DESCRIPTION
If huge page allocation fails then do one of two things:

- Increase sysctl kernel.shmmax if the maximum shared memory
  allocation size is less than the size of one huge page. (That is a
  misconfigured kernel from our perspective.) Fixes #366.

- Increase sysctl vm.nr_hugepages otherwise to have the kernel reserve
  a new huge page that we can allocate. (Try this up to three times
  per allocation, as before.)

To change system-wide sysctl values is a fairly presumptuious thing to
do. For this reason we now print clear messages about what we are doing:

    [memory: Enabling huge pages for shm: sysctl kernel.shmmax 1000000 -> 2097152]
    [memory: Provisioned a huge page: sysctl vm.nr_hugepages 0 -> 1]
    [memory: Provisioned a huge page: sysctl vm.nr_hugepages 1 -> 2]
    [memory: Provisioned a huge page: sysctl vm.nr_hugepages 2 -> 3]
    [memory: Provisioned a huge page: sysctl vm.nr_hugepages 3 -> 4]
    [memory: Provisioned a huge page: sysctl vm.nr_hugepages 4 -> 5]

On balance I feel that it is reasonable that we ask for forgiveness
rather than permission on these operations.

This is all done with ljsyscall instead of procfs. This is much nicer!