### PR TITLE
main: Improve command-line handling and usage string

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -182,12 +182,18 @@ $(RMOBJS): %: %.src
 	$(E) "MARKDOWN  $@"
 	$(Q) scripts/process-markdown $< > $@
 
-$(INCOBJ): obj/%_inc.o: %.inc Makefile | $(OBJDIR)
+$(INCOBJ): obj/%_inc.o: %.inc Makefile program/programs.inc | $(OBJDIR)
 	$(E) "INC       $@"
 	@(echo -n "return [=============["; \
 	 cat $<; \
 	 echo "]=============]") > $(basename $@).luainc
 	$(Q) luajit -bg -n $(subst /,.,$*)_inc $(basename $@).luainc $@
+
+# Create list of programs that exist
+program/programs.inc:
+	@ls -1d program/*/ | xargs basename -a > $@
+
+.FORCE: program/programs.inc
 
 # extra/ third party bits and pieces
 obj/strict.o: extra/strict.lua | $(OBJDIR)


### PR DESCRIPTION
To determine program name from argv[0]/argv[1] remove everything after
the first `-` or `.` character. This allows names like `snabbnfv`,
`snabbnfv-1.0`, `snabbnfv-lukes-turbo-charged-version`, `snabbnfv.linux`,
and so on.

Make the usage printout for `snabb` and `snabb -h` and `snabb --help` better:

    Usage: ./snabb <program> ...

    This snabb executable has the following programs built in:
      packetblaster
      snabbmark
      snabbnfv
      snsh

    For detailed usage of any program run:
      snabb <program> --help

    If you rename (or copy or symlink) this executable with one of
    the names above then that program will be chosen automatically.

The program list is determined automatically by the Makefile.