### PR TITLE
Support for 64-bit RC registers

### DIFF
--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -238,6 +238,9 @@ function hexundump(h, n)
 end
 
 function comma_value(n) -- credit http://richard.warburton.it
+   if type(n) == 'cdata' then
+      n = tonumber(n)
+   end
    if n ~= n then return "NaN" end
    local left,num,right = string.match(n,'^([^%d]*%d)(%d*)(.-)$')
    return left..(num:reverse():gsub('(%d%d%d)','%1,'):reverse())..right


### PR DESCRIPTION
I propose to introduce a new register type called RC64, which allows access to two consecutive 32-bit registers in the case of 64-bit byte and octet statistics registers. This is legal according to section 8.2.3.23 of the spec.

At the same time, the accumulator for both types of RC registers is promoted from a Lua number to a uint64_t cdata object.  In addition to allow maintaining high-capacity counters based on 32-bit registers (e.g. packet counters), this also avoids conversions from integers to doubles.

The second commit in this PR applies the new register type to maintain HC counters in the interface MIB.

I'm a bit worried about the `jit.off()` in the readrc() method of `lib.hardware.register`. It causes blacklisting of that code by the JIT, which I would rather avoid (it's not that critical, because the registers are accessed only every 5 seconds or so, but still). I've been running with the JIT enabled for lots of test runs and haven't observed any problems with the counters. It would be nice if we could find a test case for this issue to be sure it still exists.