### PR TITLE
64bit registers merge

### DIFF
--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -238,6 +238,9 @@ function hexundump(h, n)
 end
 
 function comma_value(n) -- credit http://richard.warburton.it
+   if type(n) == 'cdata' then
+      n = tonumber(n)
+   end
    if n ~= n then return "NaN" end
    local left,num,right = string.match(n,'^([^%d]*%d)(%d*)(.-)$')
    return left..(num:reverse():gsub('(%d%d%d)','%1,'):reverse())..right

--- a/src/lib/hardware/register.lua
+++ b/src/lib/hardware/register.lua
@@ -21,8 +21,6 @@ end
 
 --- Read a counter register
 function Register:readrc ()
-   -- XXX JIT of this function is causing register value to be misread.
-   jit.off(true,true)
    self.acc[0] = self.acc[0] + self.ptr[0]
    return self.acc[0]
 end


### PR DESCRIPTION
Merge Alex's support for 64-bit RC registers in the Intel driver and its SNMP support (#475).

Also disable the ancient kludge of calling `jit.off()` in the `register` module.