### PR TITLE
fix snabbswitch build on musl

### DIFF
--- a/gcc-preinclude.h
+++ b/gcc-preinclude.h
@@ -2,7 +2,7 @@
 // See: http://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html
 //      https://rjpower9000.wordpress.com/2012/04/09/fun-with-shared-libraries-version-glibc_2-14-not-found/
 
-#ifndef __ASSEMBLER__
+#if !defined(__ASSEMBLER__) && defined(__GLIBC__)
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
 #endif
 

--- a/gcc-preinclude.h
+++ b/gcc-preinclude.h
@@ -2,7 +2,10 @@
 // See: http://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html
 //      https://rjpower9000.wordpress.com/2012/04/09/fun-with-shared-libraries-version-glibc_2-14-not-found/
 
-#if !defined(__ASSEMBLER__) && defined(__GLIBC__)
+#ifndef __ASSEMBLER__
+#include <string.h>
+#ifdef __GLIBC__
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
+#endif
 #endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,20 +12,20 @@ PFLUA_VSN     := "13b194e7a214faae5c3d2916a998418fc841dbc2"
 
 TEST_SKIPPED="43"
 
-SRCDIR = $(shell find . -type d -not -regex './obj.*' -printf '%P ')
+SRCDIR = $(shell find . -type d -not -regex './obj.*' -print | xargs)
 OBJDIR = $(patsubst %,obj/%,$(SRCDIR))
 
-LUASRC = $(shell find . -regex '[^\#]*\.lua' -printf '%P ')
+LUASRC = $(shell find . -regex '[^\#]*\.lua' -print | xargs)
 PFLUASRC = $(shell cd ../deps/pflua/src && \
-	         find . -regex '[^\#]*\.lua' -printf '%P ')
-CSRC   = $(shell find . -regex '[^\#]*\.c' -not -regex './arch/.*' -printf '%P ')
-CHDR   = $(shell find . -regex '[^\#]*\.h' -printf '%P ')
-ASM    = $(shell find . -regex '[^\#]*\.dasc' -printf '%P ')
-ARCHSRC= $(shell find . -regex '^./arch/[^\#]*\.c' -printf '%P ')
-RMSRC  = $(shell find . -name  README.md.src -printf '%P ')
+	         find . -regex '[^\#]*\.lua' -print | xargs)
+CSRC   = $(shell find . -regex '[^\#]*\.c' -not -regex './arch/.*' -print | xargs | sed 's,\./,,g')
+CHDR   = $(shell find . -regex '[^\#]*\.h' -print | xargs)
+ASM    = $(shell find . -regex '[^\#]*\.dasc' -print | xargs)
+ARCHSRC= $(shell find . -regex '^./arch/[^\#]*\.c' -print | xargs | sed 's,\./,,g')
+RMSRC  = $(shell find . -name  README.md.src -print | xargs)
 # regexp is to include program/foo but not program/foo/bar
-PROGRAM = $(shell find program -regex '^[^/]+/[^/]+' -type d -printf '%P ')
-INCSRC = $(shell find . -regex '[^\#]*\.inc' -printf '%P ')
+PROGRAM = $(shell find program -regex '^[^/]+/[^/]+' -type d -print | xargs)
+INCSRC = $(shell find . -regex '[^\#]*\.inc' -print | xargs)
 
 LUAOBJ := $(patsubst %.lua,obj/%_lua.o,$(LUASRC))
 PFLUAOBJ := $(patsubst %.lua,obj/%_lua.o,$(PFLUASRC))
@@ -42,14 +42,14 @@ EXE    := bin/snabb $(patsubst %,bin/%,$(PROGRAM))
 # TESTMODS expands to:
 #   core.memory core.lib ...
 # for each module that has a top-level selftest () function.
-TESTMODS = $(shell find . -regex '[^\#]*\.lua' -printf '%P ' | \
+TESTMODS = $(shell find . -regex '[^\#]*\.lua' -print | xargs | \
              xargs grep -l '^function selftest *[[:punct:]]' | \
              sed -e 's_\.lua__' -e 's_/_._g')
 
 # TESTSCRIPTS expands to:
 #   lib/watchdog/selftest.sh ...
 # for each executable selftext.sh script in src.
-TESTSCRIPTS = $(shell find . -name "selftest.sh" -executable | xargs)
+TESTSCRIPTS = $(shell find . -name "selftest.sh" -perm +1 | xargs)
 
 PATH := ../deps/luajit/usr/local/bin:$(PATH)
 

--- a/src/apps/example/asm.dasc
+++ b/src/apps/example/asm.dasc
@@ -42,7 +42,7 @@ void* asm_make_push()
                 PROT_READ | PROT_WRITE,
                 MAP_ANON | MAP_PRIVATE, -1, 0);
   assert(memory != MAP_FAILED);
-  printf("memory = %p code_size = %ld \n", memory, code_size);
+  printf("memory = %p code_size = %ld \n", memory, (long int)code_size);
   dasm_encode(&state, memory);
   // Switch memory to executable and read-only
   assert(mprotect(memory, code_size, PROT_EXEC | PROT_READ) == 0);

--- a/src/apps/solarflare/ef_vi.h
+++ b/src/apps/solarflare/ef_vi.h
@@ -1,3 +1,4 @@
+#include <time.h>
 
 /* etherfabric/base.h */
 

--- a/src/apps/vhost/vhost_user.c
+++ b/src/apps/vhost/vhost_user.c
@@ -7,6 +7,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <string.h>
 
 #include "lib/virtio/virtio_vring.h"
 #include "vhost.h"

--- a/src/core/lib.c
+++ b/src/core/lib.c
@@ -2,7 +2,7 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 
 /* Return the current wall-clock time in nanoseconds. */
 uint64_t get_time_ns()

--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -48,7 +48,7 @@ intptr_t virtual_to_physical(intptr_t *ptr)
     return 0;
   }
   if ((data & (1ULL<<63)) == 0) {
-    fprintf(stderr, "page %lx not present: %lx", virt_page, data);
+    fprintf(stderr, "page %p not present: %p", (void*) virt_page,(void*) data);
     return 0;
   }
   return (data & ((1ULL << 55) - 1)) * 4096;

--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -29,18 +29,18 @@
 
 // Convert from virtual addresses in our own process address space to
 // physical addresses in the RAM chips.
-uint64_t virtual_to_physical(void *ptr)
+intptr_t virtual_to_physical(intptr_t *ptr)
 {
-  uint64_t virt_page;
+  intptr_t virt_page;
   static int pagemap_fd;
-  virt_page = ((uint64_t)ptr) / 4096;
+  virt_page = ((intptr_t)ptr) / 4096;
   if (pagemap_fd == 0) {
     if ((pagemap_fd = open("/proc/self/pagemap", O_RDONLY)) <= 0) {
       perror("open pagemap");
       return 0;
     }
   }
-  uint64_t data;
+  intptr_t data;
   int len;
   len = pread(pagemap_fd, &data, sizeof(data), virt_page * sizeof(uint64_t));
   if (len != sizeof(data)) {
@@ -80,7 +80,7 @@ uint64_t virtual_to_physical(void *ptr)
 void *allocate_huge_page(int size)
 {
   int shmid = -1;
-  uint64_t physical_address, virtual_address;
+  intptr_t physical_address, virtual_address;
   void *tmpptr = MAP_FAILED;  // initial kernel assigned virtual address
   void *realptr = MAP_FAILED; // remapped virtual address
   shmid = shmget(IPC_PRIVATE, size, SHM_HUGETLB | IPC_CREAT | SHM_R | SHM_W);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -1,4 +1,4 @@
 int      lock_memory();
 void    *allocate_huge_page(int size);
-uint64_t phys_page(uint64_t virt_page);
+intptr_t phys_page(intptr_t virt_page);
 


### PR DESCRIPTION
Compile-time errors fixed by adding includes and changing some types.
Avoiding the glibc memcpy demibug workaround builds luajit for non-glibc platforms like musl. 