### PR TITLE
Added doc/branches.md: List of active development branches

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -1,0 +1,42 @@
+## Snabb Switch development branches
+
+The branches listed below are automatically synchronized with the
+SnabbCo account on Github. Users typically get all of these branches
+together by pulling from the main repository.
+
+The current state of each branch with respect to master is visible here:
+
+- https://github.com/SnabbCo/snabbswitch/branches/all
+
+#### master
+
+    BRANCH: master git://github.com/lukego/snabbswitch
+    Synchronization point with changes recommended for all users.
+    
+    - Makes monthly releases.
+    - Changes are gated by the SnabbBot CI
+    - Currently Linux/x86-64 with GNU tools (more in the future)
+    
+    Maintainer: Luke Gorrie <luke@snabb.co> and Max Rottenkolber <max@mr.gy>
+
+#### documenation-fixups
+
+    BRANCH: documentation-fixups git://github.com/eugeneia/snabbswitch
+    Documentation fixes and improvements.
+    
+    Maintainer: Max Rottenkolber <max@mr.gy>
+
+#### nfv
+    
+    BRANCH: nfv git://github.com/lukego/snabbswitch
+    snabbnfv application development branch.
+    
+    Maintainer: Luke Gorrie <luke@snabb.co>
+
+#### vpn
+    
+    BRANCH: vpn git://github.com/alexandergall/snabbswitch
+    VPN application development branch.
+    
+    Maintainer: Alexander Gall <gall@switch.ch>
+


### PR DESCRIPTION
`branches.md` serves three purposes:

- Help users find out what branches exist.
- Help developers advertise their branches.
- Help to automatically sync branches onto the SnabbCo repository.

The [Github SnabbCo/snabbswitch branches page](https://github.com/SnabbCo/snabbswitch/branches/all) shows the current status of all these branches with respect to master. Users should automatically receive all branches when pulling from the main repository.

This is intended to help new long-lived branches to be used and develop features that can synchronize with master and other branches over time.

Notes:

- There is currently a small cronjob using this file to automatically push changes from known branches onto the master repository.
- If you are the maintainer of a known branch then your pushes will automatically be synced.
- The sync is done without `--force` so rebases are not supported without manual intervention. The intended workflow is that the branches pull from master (and each other) and not rebase.

Let this wild experiment begin! :-)