### PR TITLE
neutron2snabb: Added automatic database schema detection

### DIFF
--- a/src/program/snabbnfv/neutron2snabb/neutron2snabb_schema.lua
+++ b/src/program/snabbnfv/neutron2snabb/neutron2snabb_schema.lua
@@ -1,0 +1,61 @@
+-- neutron2snabb_schema: Scan mysqldump SQL files for schema informaion
+module(..., package.seeall)
+
+local lib = require("core.lib")
+
+function read (directory, tables)
+   local schema = {}
+   for _, t in ipairs(tables) do
+      schema[t] = columns(("%s/%s.sql"):format(directory, t))
+   end
+   return schema
+end
+
+-- Scan the order of keys from a table definition.
+
+
+-- Return the columns of the named file in an array.
+--
+-- The array may containing extraneous trailing items but must give
+-- the actual columns in order.
+function columns (filename)
+   -- Array of columns.
+   local columns = {}
+   local sql = lib.readfile(filename, '*a')
+   local definition = sql:match("CREATE TABLE `[^`]*` (%b())")
+   assert(definition, "failed to find CREATE TABLE definition")
+   -- The expected table definition format is:
+   --
+   --   CREATE TABLE `ml2_port_bindings` (
+   --     `port_id` varchar(36) NOT NULL,
+   --     `host` varchar(255) NOT NULL,
+   --     ...
+   --   ) ...
+   --
+   -- We scan this and pick up the `identifiers`.
+   definition:gsub("`([^`]*)`", function (id)
+                      table.insert(columns, id)
+   end)
+   return columns
+end
+
+function selftest ()
+   print("selftest: neutron2snabb_schema")
+   local neutron2snabb = require("program.snabbnfv.neutron2snabb.neutron2snabb")
+   -- Check that the schema we extract from the test database is
+   -- compaible with the default schema. (That is expected for this
+   -- particular data set.)
+   local dir = "program/snabbnfv/test_fixtures/neutron_csv/db2"
+   local schema = read(dir, neutron2snabb.schema_tables)
+   for tab, cols in pairs(neutron2snabb.default_schemas) do
+      assert(schema[tab], "missing schema table: " .. tab)
+      for i, col in ipairs(cols) do
+         if schema[tab][i] ~= col then
+            error(("Column mismatch: %s[%d] is %s (expected %s)"):format(
+                  tab, i, schema[tab][i], col))
+         end
+      end
+   end
+   print("selftest: ok")
+end
+

--- a/src/program/snabbnfv/neutron2snabb/selftest.sh
+++ b/src/program/snabbnfv/neutron2snabb/selftest.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "selftest: neutron2snabb/selftest.sh"
+
+set -e
+
+export TESTDIR=/tmp/snabbtest
+
+# Database 1
+
+mkdir -p $TESTDIR
+
+./snabb snabbnfv neutron2snabb \
+	program/snabbnfv/test_fixtures/neutron_csv $TESTDIR cdn1
+
+diff $TESTDIR/port0 program/snabbnfv/test_fixtures/nfvconfig/reference/port0
+diff $TESTDIR/port2 program/snabbnfv/test_fixtures/nfvconfig/reference/port2
+echo "File contents as expected."
+
+echo "selftest: ok"
+
+rm -r $TESTDIR
+

--- a/src/program/snabbnfv/test_fixtures/neutron_csv/ml2_network_segments.sql
+++ b/src/program/snabbnfv/test_fixtures/neutron_csv/ml2_network_segments.sql
@@ -1,0 +1,43 @@
+-- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
+--
+-- Host: nbn-l8-dev2-os-8    Database: neutron_ml2
+-- ------------------------------------------------------
+-- Server version	5.5.40-0ubuntu0.14.04.1-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `ml2_network_segments`
+--
+
+DROP TABLE IF EXISTS `ml2_network_segments`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ml2_network_segments` (
+  `id` varchar(36) NOT NULL,
+  `network_id` varchar(36) NOT NULL,
+  `network_type` varchar(32) NOT NULL,
+  `physical_network` varchar(64) DEFAULT NULL,
+  `segmentation_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `network_id` (`network_id`),
+  CONSTRAINT `ml2_network_segments_ibfk_1` FOREIGN KEY (`network_id`) REFERENCES `networks` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed

--- a/src/program/snabbnfv/test_fixtures/neutron_csv/ml2_port_bindings.sql
+++ b/src/program/snabbnfv/test_fixtures/neutron_csv/ml2_port_bindings.sql
@@ -1,0 +1,47 @@
+-- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
+--
+-- Host: nbn-l8-dev2-os-8    Database: neutron_ml2
+-- ------------------------------------------------------
+-- Server version	5.5.40-0ubuntu0.14.04.1-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `ml2_port_bindings`
+--
+
+DROP TABLE IF EXISTS `ml2_port_bindings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ml2_port_bindings` (
+  `port_id` varchar(36) NOT NULL,
+  `host` varchar(255) NOT NULL,
+  `vif_type` varchar(64) NOT NULL,
+  `driver` varchar(64) DEFAULT NULL,
+  `segment` varchar(36) DEFAULT NULL,
+  `vnic_type` varchar(64) NOT NULL DEFAULT 'normal',
+  `vif_details` varchar(4095) NOT NULL DEFAULT '',
+  `profile` varchar(4095) NOT NULL DEFAULT '',
+  PRIMARY KEY (`port_id`),
+  KEY `segment` (`segment`),
+  CONSTRAINT `ml2_port_bindings_ibfk_1` FOREIGN KEY (`port_id`) REFERENCES `ports` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `ml2_port_bindings_ibfk_2` FOREIGN KEY (`segment`) REFERENCES `ml2_network_segments` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed

--- a/src/program/snabbnfv/test_fixtures/neutron_csv/networks.sql
+++ b/src/program/snabbnfv/test_fixtures/neutron_csv/networks.sql
@@ -1,0 +1,42 @@
+-- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
+--
+-- Host: nbn-l8-dev2-os-8    Database: neutron_ml2
+-- ------------------------------------------------------
+-- Server version	5.5.40-0ubuntu0.14.04.1-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `networks`
+--
+
+DROP TABLE IF EXISTS `networks`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `networks` (
+  `tenant_id` varchar(255) DEFAULT NULL,
+  `id` varchar(36) NOT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `status` varchar(16) DEFAULT NULL,
+  `admin_state_up` tinyint(1) DEFAULT NULL,
+  `shared` tinyint(1) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed

--- a/src/program/snabbnfv/test_fixtures/neutron_csv/ports.sql
+++ b/src/program/snabbnfv/test_fixtures/neutron_csv/ports.sql
@@ -1,0 +1,47 @@
+-- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
+--
+-- Host: nbn-l8-dev2-os-8    Database: neutron_ml2
+-- ------------------------------------------------------
+-- Server version	5.5.40-0ubuntu0.14.04.1-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `ports`
+--
+
+DROP TABLE IF EXISTS `ports`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ports` (
+  `tenant_id` varchar(255) DEFAULT NULL,
+  `id` varchar(36) NOT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `network_id` varchar(36) NOT NULL,
+  `mac_address` varchar(32) NOT NULL,
+  `admin_state_up` tinyint(1) NOT NULL,
+  `status` varchar(16) NOT NULL,
+  `device_id` varchar(255) NOT NULL,
+  `device_owner` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `network_id` (`network_id`),
+  CONSTRAINT `ports_ibfk_1` FOREIGN KEY (`network_id`) REFERENCES `networks` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed

--- a/src/program/snabbnfv/test_fixtures/neutron_csv/securitygroupportbindings.sql
+++ b/src/program/snabbnfv/test_fixtures/neutron_csv/securitygroupportbindings.sql
@@ -1,0 +1,41 @@
+-- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
+--
+-- Host: nbn-l8-dev2-os-8    Database: neutron_ml2
+-- ------------------------------------------------------
+-- Server version	5.5.40-0ubuntu0.14.04.1-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `securitygroupportbindings`
+--
+
+DROP TABLE IF EXISTS `securitygroupportbindings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `securitygroupportbindings` (
+  `port_id` varchar(36) NOT NULL,
+  `security_group_id` varchar(36) NOT NULL,
+  PRIMARY KEY (`port_id`,`security_group_id`),
+  KEY `security_group_id` (`security_group_id`),
+  CONSTRAINT `securitygroupportbindings_ibfk_1` FOREIGN KEY (`port_id`) REFERENCES `ports` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `securitygroupportbindings_ibfk_2` FOREIGN KEY (`security_group_id`) REFERENCES `securitygroups` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed

--- a/src/program/snabbnfv/test_fixtures/neutron_csv/securitygrouprules.sql
+++ b/src/program/snabbnfv/test_fixtures/neutron_csv/securitygrouprules.sql
@@ -1,0 +1,50 @@
+-- MySQL dump 10.13  Distrib 5.5.40, for debian-linux-gnu (x86_64)
+--
+-- Host: nbn-l8-dev2-os-8    Database: neutron_ml2
+-- ------------------------------------------------------
+-- Server version	5.5.40-0ubuntu0.14.04.1-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `securitygrouprules`
+--
+
+DROP TABLE IF EXISTS `securitygrouprules`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `securitygrouprules` (
+  `tenant_id` varchar(255) DEFAULT NULL,
+  `id` varchar(36) NOT NULL,
+  `security_group_id` varchar(36) NOT NULL,
+  `remote_group_id` varchar(36) DEFAULT NULL,
+  `direction` enum('ingress','egress') DEFAULT NULL,
+  `ethertype` varchar(40) DEFAULT NULL,
+  `protocol` varchar(40) DEFAULT NULL,
+  `port_range_min` int(11) DEFAULT NULL,
+  `port_range_max` int(11) DEFAULT NULL,
+  `remote_ip_prefix` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `security_group_id` (`security_group_id`),
+  KEY `remote_group_id` (`remote_group_id`),
+  CONSTRAINT `securitygrouprules_ibfk_1` FOREIGN KEY (`security_group_id`) REFERENCES `securitygroups` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `securitygrouprules_ibfk_2` FOREIGN KEY (`remote_group_id`) REFERENCES `securitygroups` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed


### PR DESCRIPTION
neutron2snabb now scans the *.sql files produced by mysqldump to determine the order of columns in the database dump.

The original selftest.sh regression test case is reintroduced to confirm that the schema is understood correctly and the same configuration files are generated.

This depends on the neutron_sync_master to store the *.sql files, which is the subject of a separate change. If these files are not present then the old hard-coded default is used.