### PR TITLE
Makefile: Fix dependency error that broke 'make -j'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install_compute_node: install
 	install -D src/scripts/sysv/init.d/snabb-nfv-sync-agent ${PREFIX}/etc/init.d/snabb-nfv-sync-agent
 	install -D src/scripts/sysv/default/snabb-nfv-sync-agent ${PREFIX}/etc/default/snabb-nfv-sync-agent
 
-$(LUAJIT): check_luajit deps/luajit/Makefile
+$(LUAJIT): check_luajit
 	@echo 'Building LuaJIT'
 	@(cd deps/luajit && \
 	 $(MAKE) PREFIX=`pwd`/usr/local \


### PR DESCRIPTION
There was a mistake in the LuaJIT dependency that would cause a parallel make to break. (It would expect to find the LuaJIT Makefile while asynchronously cloning the repo.)

Fixes #471.