### PR TITLE
Modify checksum API

### DIFF
--- a/src/arch/avx2.c
+++ b/src/arch/avx2.c
@@ -63,7 +63,7 @@ static inline uint32_t cksum_avx2_loop(unsigned char *p, size_t n)
 
 uint16_t cksum_avx2(unsigned char *p, size_t n, uint32_t initial)
 {
-    uint32_t sum = ntohs(initial);
+    uint32_t sum = initial;
 
     if (n < 128) { return cksum_generic(p, n, initial); }
     if (n >= 64) {

--- a/src/arch/sse2.c
+++ b/src/arch/sse2.c
@@ -66,7 +66,7 @@ static inline uint32_t cksum_sse2_loop(unsigned char *p, size_t n)
 
 uint16_t cksum_sse2(unsigned char *p, size_t n, uint32_t initial)
 {
-  uint32_t sum = ntohs(initial);
+  uint32_t sum = initial;
 
   if (n < 128) { return cksum_generic(p, n, initial); }
   int unaligned = (unsigned long) p & 0xf;

--- a/src/lib/checksum.h
+++ b/src/lib/checksum.h
@@ -1,14 +1,14 @@
 // Calculate IP checksum using SSE2 instructions.
 // (This will crash if you call it on a CPU that does not support SSE.)
-uint16_t cksum_sse2(unsigned char *p, size_t n, uint32_t initial);
+uint16_t cksum_sse2(unsigned char *p, size_t n, uint16_t initial);
 
 // Calculate IP checksum using AVX2 instructions.
 // (This will crash if you call it on a CPU that does not support AVX2.)
-uint16_t cksum_avx2(unsigned char *p, size_t n, uint32_t initial);
+uint16_t cksum_avx2(unsigned char *p, size_t n, uint16_t initial);
 
 // Calculate IP checksum using portable C code.
 // This works on all hardware.
-uint16_t cksum_generic(unsigned char *p, size_t n, uint32_t initial);
+uint16_t cksum_generic(unsigned char *p, size_t n, uint16_t initial);
 
 // Incrementally update checksum when modifying a 16-bit value.
 void checksum_update_incremental_16(uint16_t* checksum_cell,

--- a/src/lib/checksum.lua
+++ b/src/lib/checksum.lua
@@ -2,7 +2,32 @@ module(...,package.seeall)
 
 -- This module exposes the interface:
 --   checksum.ipsum(pointer, length, initial) => checksum
--- where checksum is in network byte order.
+--
+-- pointer is a pointer to an array of unsigned 16-bit integers in
+-- network byte order of length length, which is padded with a
+-- zero-byte if necessary. initial is an unsigned 16-bit number in
+-- host byte order which is used as the starting value of the
+-- accumulator.  The result is the IP checksum over the data in host
+-- byte order.
+--
+-- The initial argument can be used to verify a checksum or to
+-- calculate the checksum in an incremental manner over chunks of
+-- memory.  The synopsis to check whether the checksum over a block of
+-- data is equal to a given value is the following
+--
+--  if ipsum(pointer, length, value) == 0 then
+--    -- checksum correct
+--  else
+--    -- checksum incorrect
+--  end
+--
+-- To chain the calculation of checksums over multiple blocks of data
+-- together to obtain the overall checksum, one needs to pass the
+-- one's complement of the checksum of one block as initial value to
+-- the call of ipsum() for the following block, e.g.
+--
+--  local sum1 = ipsum(data1, length1, 0)
+--  local total_sum = ipsum(data2, length2, bit.bnot(sum1))
 --
 -- The actual implementation is chosen based on running CPU.
 

--- a/src/lib/protocol/gre.lua
+++ b/src/lib/protocol/gre.lua
@@ -3,7 +3,8 @@ local ffi = require("ffi")
 local C = ffi.C
 local header = require("lib.protocol.header")
 local lib = require("core.lib")
-local bitfield, update_csum, finish_csum = lib.bitfield, lib.update_csum, lib.finish_csum
+local bitfield = lib.bitfield
+local ipsum = require("lib.checksum").ipsum
 
 -- GRE uses a variable-length header as specified by RFCs 2784 and
 -- 2890.  The actual size is determined by flag bits in the base
@@ -106,8 +107,9 @@ local function checksum(header, payload, length)
    local csum_in = header.csum;
    header.csum = 0;
    header.reserved1 = 0;
-   local csum = finish_csum(update_csum(payload, length,
-					update_csum(header, ffi.sizeof(header), 0)))
+   local csum = ipsum(payload, length,
+		      bit.bnot(ipsum(ffi.cast("uint8_t *", header),
+				     ffi.sizeof(header), 0)))
    header.csum = csum_in
    return csum
 end

--- a/src/lib/protocol/icmp/header.lua
+++ b/src/lib/protocol/icmp/header.lua
@@ -60,12 +60,13 @@ local function checksum(header, payload, length, ipv6)
    if ipv6 then
       -- Checksum IPv6 pseudo-header
       local ph = ipv6:pseudo_header(length + ffi.sizeof(header), 58)
-      csum = ipsum(ph, ffi.sizeof(ph), 0)
+      csum = ipsum(ffi.cast("uint8_t *", ph), ffi.sizeof(ph), 0)
    end
    -- Add ICMP header
    local csum_rcv = header.checksum
    header.checksum = 0
-   csum = ipsum(header, ffi.sizeof(header), bit.bnot(csum))
+   csum = ipsum(ffi.cast("uint8_t *", header),
+		ffi.sizeof(header), bit.bnot(csum))
    header.checksum = csum_rcv
    -- Add ICMP payload
    return ipsum(payload, length, bit.bnot(csum))

--- a/src/lib/protocol/icmp/header.lua
+++ b/src/lib/protocol/icmp/header.lua
@@ -3,6 +3,7 @@ local ffi = require("ffi")
 local C = ffi.C
 local header = require("lib.protocol.header")
 local lib = require("core.lib")
+local ipsum = require("lib.checksum").ipsum
 
 -- XXX IPv4 and IPv6 use the same ICMP header format but distinct
 -- number spaces for type and code.  This class needs to be subclassed
@@ -59,16 +60,15 @@ local function checksum(header, payload, length, ipv6)
    if ipv6 then
       -- Checksum IPv6 pseudo-header
       local ph = ipv6:pseudo_header(length + ffi.sizeof(header), 58)
-      csum = lib.update_csum(ph, ffi.sizeof(ph), csum)
+      csum = ipsum(ph, ffi.sizeof(ph), 0)
    end
    -- Add ICMP header
    local csum_rcv = header.checksum
    header.checksum = 0
-   csum = lib.update_csum(header, ffi.sizeof(header), csum)
+   csum = ipsum(header, ffi.sizeof(header), bit.bnot(csum))
    header.checksum = csum_rcv
    -- Add ICMP payload
-   csum = lib.update_csum(payload, length, csum)
-   return lib.finish_csum(csum)
+   return ipsum(payload, length, bit.bnot(csum))
 end
 
 function icmp:checksum (payload, length, ipv6)

--- a/src/lib/protocol/ipv4.lua
+++ b/src/lib/protocol/ipv4.lua
@@ -144,7 +144,8 @@ function ipv4:protocol (protocol)
 end
 
 function ipv4:checksum ()
-   self:header().checksum = C.htons(ipsum(self:header(), self:sizeof(), 0))
+   self:header().checksum = C.htons(ipsum(ffi.cast("uint8_t *", self:header()),
+					  self:sizeof(), 0))
    return C.ntohs(self:header().checksum)
 end
 

--- a/src/lib/protocol/ipv4.lua
+++ b/src/lib/protocol/ipv4.lua
@@ -3,6 +3,7 @@ local ffi = require("ffi")
 local C = ffi.C
 local lib = require("core.lib")
 local header = require("lib.protocol.header")
+local ipsum = require("lib.checksum").ipsum
 
 -- TODO: generalize
 local AF_INET = 2
@@ -143,8 +144,7 @@ function ipv4:protocol (protocol)
 end
 
 function ipv4:checksum ()
-   local csum = lib.update_csum(self:header(), self:sizeof())
-   self:header().checksum = C.htons(lib.finish_csum(csum))
+   self:header().checksum = C.htons(ipsum(self:header(), self:sizeof(), 0))
    return C.ntohs(self:header().checksum)
 end
 

--- a/src/lib/protocol/tcp.lua
+++ b/src/lib/protocol/tcp.lua
@@ -147,11 +147,12 @@ function tcp:checksum (payload, length, ip)
       if ip then
          -- Checksum IP pseudo-header
          local ph = ip:pseudo_header(length + self:sizeof(), 6)
-         csum = ipsum(ph, ffi.sizeof(ph), 0)
+         csum = ipsum(ffi.cast("uint8_t *", ph), ffi.sizeof(ph), 0)
       end
       -- Add TCP header
       h.checksum = 0
-      csum = ipsum(h, self:sizeof(), bit.bnot(csum))
+      csum = ipsum(ffi.cast("uint8_t *", h),
+		   self:sizeof(), bit.bnot(csum))
       -- Add TCP payload
       h.checksum = C.htons(ipsum(payload, length, bit.bnot(csum)))
    end

--- a/src/lib/protocol/tcp.lua
+++ b/src/lib/protocol/tcp.lua
@@ -3,6 +3,7 @@ local ffi = require("ffi")
 local C = ffi.C
 local lib = require("core.lib")
 local header = require("lib.protocol.header")
+local ipsum = require("lib.checksum").ipsum
 
 local tcp_header_t = ffi.typeof[[
 struct {
@@ -146,14 +147,13 @@ function tcp:checksum (payload, length, ip)
       if ip then
          -- Checksum IP pseudo-header
          local ph = ip:pseudo_header(length + self:sizeof(), 6)
-         csum = lib.update_csum(ph, ffi.sizeof(ph), csum)
+         csum = ipsum(ph, ffi.sizeof(ph), 0)
       end
       -- Add TCP header
       h.checksum = 0
-      csum = lib.update_csum(h, self:sizeof(), csum)
+      csum = ipsum(h, self:sizeof(), bit.bnot(csum))
       -- Add TCP payload
-      csum = lib.update_csum(payload, length, csum)
-      h.checksum = C.htons(lib.finish_csum(csum))
+      h.checksum = C.htons(ipsum(payload, length, bit.bnot(csum)))
    end
    return C.ntohs(h.checksum)
 end

--- a/src/lib/protocol/udp.lua
+++ b/src/lib/protocol/udp.lua
@@ -2,6 +2,7 @@ module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C
 local header = require("lib.protocol.header")
+local ipsum = require("lib.checksum").ipsum
 
 local udp_header_t = ffi.typeof[[
 struct {
@@ -64,14 +65,13 @@ function udp:checksum (payload, length, ip)
       if ip then
          -- Checksum IP pseudo-header
          local ph = ip:pseudo_header(length + self:sizeof(), 17)
-         csum = lib.update_csum(ph, ffi.sizeof(ph), csum)
+         csum = ipsum(ph, ffi.sizeof(ph), 0)
       end
       -- Add UDP header
       h.checksum = 0
-      csum = lib.update_csum(h, self:sizeof(), csum)
+      csum = ipsum(h, self:sizeof(), bit.bnot(csum))
       -- Add UDP payload
-      csum = lib.update_csum(payload, length, csum)
-      h.checksum = C.htons(lib.finish_csum(csum))
+      h.checksum = C.htons(ipsum(payload, length, bit.bnot(csum)))
    end
    return C.ntohs(h.checksum)
 end

--- a/src/lib/protocol/udp.lua
+++ b/src/lib/protocol/udp.lua
@@ -65,11 +65,12 @@ function udp:checksum (payload, length, ip)
       if ip then
          -- Checksum IP pseudo-header
          local ph = ip:pseudo_header(length + self:sizeof(), 17)
-         csum = ipsum(ph, ffi.sizeof(ph), 0)
+         csum = ipsum(ffi.cast("uint8_t *", ph), ffi.sizeof(ph), 0)
       end
       -- Add UDP header
       h.checksum = 0
-      csum = ipsum(h, self:sizeof(), bit.bnot(csum))
+      csum = ipsum(ffi.cast("uint8_t *", h),
+		   self:sizeof(), bit.bnot(csum))
       -- Add UDP payload
       h.checksum = C.htons(ipsum(payload, length, bit.bnot(csum)))
    end


### PR DESCRIPTION
I'm not happy with the current API for the IP checksum implementation.  I have discussed the issues in the thread https://groups.google.com/forum/#!topic/snabb-devel/nlifqWTDqzc

This PR contains the following proposed changes:

The type of the `initial` argument is changed to uint16_t throughout and its endianness is now expected to be the same as the output of ipsum(). The old code used endian conversions in an asymmetrical manner, which I find very awkward.

The code for cksum_generic() is cleaned up a bit.

The documentation in the code has been extended to describe the full semantics of ipsum(). In particular, the output of ipsum() was previously described as being in network byte order, when, in fact, it is in host byte order, i.e. an endian conversion is required to write the checksum to memory in network byte order.

I think that the convention that the result of ipsum() and the `initial` argument are in host byte order is the natural choice. Conversions have to be performed when a checksum is read from or written to a packet buffer.  