### PR TITLE
snabb: Detect errors during startup

### DIFF
--- a/src/core/snabbswitch.c
+++ b/src/core/snabbswitch.c
@@ -14,6 +14,6 @@ int main(int snabb_argc, char **snabb_argv)
   argv = snabb_argv;
   lua_State* L = luaL_newstate();
   luaL_openlibs(L);
-  return luaL_dostring(L, "require \"core.main\"");
+  return luaL_dostring(L, "require \"core.startup\"");
 }
 

--- a/src/core/startup.lua
+++ b/src/core/startup.lua
@@ -1,0 +1,5 @@
+local ok, err = pcall(require, "core.main")
+if not ok then
+   print("startup: unhandled exception")
+   print(err)
+end

--- a/src/core/startup.lua
+++ b/src/core/startup.lua
@@ -2,4 +2,5 @@ local ok, err = pcall(require, "core.main")
 if not ok then
    print("startup: unhandled exception")
    print(err)
+   os.exit(1)
 end


### PR DESCRIPTION
Loading the core.main module is now wrapped in a `pcall()` to catch and report errors.

Previously errors occurring early during startup would cause a silent exit.

This should help to diagnose problems such as the one affecting #483.