### PR TITLE
Vm sandbox

### DIFF
--- a/src/apps/basic/sink.lua
+++ b/src/apps/basic/sink.lua
@@ -1,0 +1,9 @@
+
+function push()
+   for _, i in ipairs(input) do
+      for _ = 1, link.nreadable(i) do
+         local p = link.receive(i)
+         packet.free(p)
+      end
+   end
+end

--- a/src/apps/basic/source.lua
+++ b/src/apps/basic/source.lua
@@ -1,0 +1,16 @@
+
+local size = size or 60
+local pkt = packet.from_pointer (ffi.new("char[?]", size), size)
+
+function pull()
+   for _, o in ipairs(output) do
+      for i = 1, link.nwritable(o) do
+         link.transmit(o, packet.clone(pkt))
+      end
+   end
+end
+
+
+function stop()
+   packet.free(pkt)
+end

--- a/src/apps/basic/test.lua
+++ b/src/apps/basic/test.lua
@@ -1,0 +1,11 @@
+module(..., package.seeall)
+
+function selftest()
+   local c = config.new()
+   config.app(c, 'source', 'apps.basic.source', {size=120})
+   config.app(c, 'sink', 'apps.basic.sink')
+   config.link(c, 'source.output -> sink.input')
+   engine.configure(c)
+
+   engine.main{duration=1, report={showlinks=true}}
+end

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -211,6 +211,11 @@ function apply_config_actions (actions, conf)
    -- commit changes
    app_table, link_table = new_app_table, new_link_table
    app_array, link_array = new_app_array, new_link_array
+   for _, app in pairs(app_table) do
+      if app.inject_links then
+         app:inject_links()
+      end
+   end
 end
 
 -- Call this to "run snabb switch".

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -5,6 +5,7 @@ local lib    = require("core.lib")
 local link   = require("core.link")
 local config = require("core.config")
 local timer  = require("core.timer")
+local stats  = require('core.stats')
 local zone   = require("jit.zone")
 local ffi    = require("ffi")
 local C      = ffi.C
@@ -26,9 +27,7 @@ configuration = config.new()
 -- Counters for statistics.
 -- TODO: Move these over to the counters framework
 breaths = 0			-- Total breaths taken
-frees   = 0			-- Total packets freed
-freebits = 0			-- Total packet bits freed (for 10GbE)
-freebytes = 0			-- Total packet bytes freed
+stats.new()
 
 -- Breathing regluation to reduce CPU usage when idle by calling usleep(3).
 --
@@ -97,7 +96,7 @@ function restart_dead_apps ()
 end
 
 -- Configure the running app network to match new_configuration.
--- 
+--
 -- Successive calls to configure() will migrate from the old to the
 -- new app network by making the changes needed.
 function configure (new_config)
@@ -186,7 +185,7 @@ function apply_config_actions (actions, conf)
    for _, action in ipairs({'stop', 'restart', 'keep', 'reconfig', 'start'}) do
       for _, name in ipairs(actions[action]) do
 	 if log and action ~= 'keep' then
-            io.write("engine: ", action, " app ", name, "\n") 
+            io.write("engine: ", action, " app ", name, "\n")
          end
 	 ops[action](name)
       end
@@ -237,9 +236,6 @@ function main (options)
 end
 
 local nextbreath
-local lastfrees = 0
-local lastfreebits = 0
-local lastfreebytes = 0
 -- Wait between breaths to keep frequency with Hz.
 function pace_breathing ()
    if Hz then
@@ -251,15 +247,12 @@ function pace_breathing ()
       end
       nextbreath = math.max(nextbreath + 1/Hz, monotonic_now)
    else
-      if lastfrees == frees then
-	 sleep = math.min(sleep + 1, maxsleep)
-	 C.usleep(sleep)
+      if stats.breathe() > 0 then
+         sleep = math.min(sleep + 1, maxsleep)
+         C.usleep(sleep)
       else
-	 sleep = math.floor(sleep/2)
+         sleep = math.floor(sleep/2)
       end
-      lastfrees = frees
-      lastfreebytes = freebytes
-      lastfreebits = freebits
    end
 end
 
@@ -319,14 +312,11 @@ end
 --   fpb  - frees per breath
 --   bpp  - bytes per packet (average packet size)
 local lastloadreport = nil
-local reportedfrees = nil
 local reportedbreaths = nil
 function report_load ()
    if lastloadreport then
       local interval = now() - lastloadreport
-      local newfrees   = frees - reportedfrees
-      local newbytes   = freebytes - reportedfreebytes
-      local newbits    = freebits - reportedfreebits
+      local newfrees, newbytes, newbits = stats.report()
       local newbreaths = breaths - reportedbreaths
       local fps = math.floor(newfrees/interval)
       local fbps = math.floor(newbits/interval)
@@ -341,9 +331,6 @@ function report_load ()
 	    sleep))
    end
    lastloadreport = now()
-   reportedfrees = frees
-   reportedfreebits = freebits
-   reportedfreebytes = freebytes
    reportedbreaths = breaths
 end
 

--- a/src/core/config.lua
+++ b/src/core/config.lua
@@ -3,6 +3,7 @@
 module(..., package.seeall)
 
 local lib = require("core.lib")
+local sandbox_loader = require('core.sandbox_loader')
 
 -- API: Create a new configuration.
 -- Initially there are no apps or links.
@@ -23,8 +24,11 @@ end
 --
 -- Example: config.app(c, "nic", Intel82599, {pciaddr = "0000:00:01.00"})
 function app (config, name, class, arg)
-   arg = arg or "nil"
+--    arg = arg or "nil"
    assert(type(name) == "string", "name must be a string")
+   if type(class) == 'string' then
+      class = sandbox_loader(class)
+   end
    assert(type(class) == "table", "class must be a table")
    config.apps[name] = { class = class, arg = arg}
 end

--- a/src/core/freelist.lua
+++ b/src/core/freelist.lua
@@ -2,11 +2,21 @@ module(...,package.seeall)
 
 local ffi = require("ffi")
 
+function maketype(type, sfx)
+   return ffi.typeof([[
+      struct {
+         int nfree, max;
+         $ list[?];
+      }
+   ]]..(sfx or ''), ffi.typeof(type))
+end
+
 function new (type, size)
-   return { nfree = 0,
-            max = size,
-            -- XXX Better LuaJIT idiom for specifying the array type?
-            list = ffi.new(type.."[?]", size) }
+   return maketype(type)(size, {nfree=0, max=size})
+end
+
+function receive(type, ptr)
+   return ffi.cast(maketype(type, '*'), ptr)
 end
 
 function add (freelist, element)
@@ -28,4 +38,3 @@ end
 function nfree (freelist)
    return freelist.nfree
 end
-

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -22,7 +22,13 @@ local max_payload = tonumber(C.PACKET_PAYLOAD_SIZE)
 local max_packets = 1e5
 local packet_allocation_step = 1000
 local packets_allocated = 0
-local packets_fl = freelist.new("struct packet *", max_packets)
+if rawget(_G, '_shared_packets_fl') then
+   packets_fl = freelist.receive('struct packet *', _shared_packets_fl)
+else
+   packets_fl = freelist.new("struct packet *", max_packets)
+   _G._shared_packets_fl = packets_fl
+end
+local packets_fl = packets_fl
 
 -- Return an empty packet.
 function allocate ()
@@ -79,7 +85,7 @@ function from_string (d)         return from_pointer(d, #d) end
 local function free_internal (p)
    p.length = 0
    freelist_add(packets_fl, p)
-end   
+end
 
 function free (p)
    engine.frees = engine.frees + 1

--- a/src/core/sandbox_loader.lua
+++ b/src/core/sandbox_loader.lua
@@ -214,6 +214,7 @@ local function new_app_vm()
    vm:add_globals({_shared_packets_fl = _shared_packets_fl})
    assert(vm:load([[
       ffi = require('ffi')
+      require('lib.lua.class')
       engine = require('core.app')
       packet = require('core.packet')
       link = require('core.link')

--- a/src/core/sandbox_loader.lua
+++ b/src/core/sandbox_loader.lua
@@ -1,0 +1,305 @@
+
+local ffi = require ('ffi')
+local C = ffi.C
+
+-- BEGIN Lua State handling functions
+
+ffi.cdef [[
+   /*
+    * copied from lua.h
+    */
+
+   typedef struct lua_State lua_State;
+   typedef double lua_Number;
+
+
+   static const int LUA_GLOBALSINDEX = (-10002);
+   static const int LUA_MULTRET = (-1);
+
+   // basic types
+   enum {
+      LUA_TNONE = (-1),
+      LUA_TNIL,
+      LUA_TBOOLEAN,
+      LUA_TLIGHTUSERDATA,
+      LUA_TNUMBER,
+      LUA_TSTRING,
+      LUA_TTABLE,
+      LUA_TFUNCTION,
+      LUA_TUSERDATA,
+      LUA_TTHREAD,
+   };
+
+
+   void lua_close (lua_State *L);
+   void lua_createtable (lua_State *L, int narr, int nrec);
+   void lua_getfield (lua_State *L, int index, const char *k);
+   int lua_gettop (lua_State *L);
+   int lua_next (lua_State *L, int index);
+   int lua_pcall (lua_State *L, int nargs, int nresults, int errfunc);
+   void lua_pushboolean (lua_State *L, int b);
+   void lua_pushlightuserdata (lua_State *L, void *p);
+   void lua_pushlstring (lua_State *L, const char *s, size_t len);
+   void lua_pushnil (lua_State *L);
+   void lua_pushnumber (lua_State *L, lua_Number n);
+   void lua_pushvalue (lua_State *L, int index);
+   void lua_settable (lua_State *L, int index);
+   void lua_settop (lua_State *L, int index);
+   int lua_toboolean (lua_State *L, int index);
+   const char *lua_tolstring (lua_State *L, int index, size_t *len);
+   lua_Number lua_tonumber (lua_State *L, int index);
+   int lua_type (lua_State *L, int index);
+
+   int luaL_loadbuffer (lua_State *L, const char *buff, size_t sz, const char *name);
+   lua_State *luaL_newstate (void);
+   void luaL_openlibs (lua_State *L);
+]]
+
+local lua_State_t = ffi.typeof ('lua_State')
+local lua_State_mt = {}
+lua_State_mt.__index = lua_State_mt
+
+
+-- FFI object constructor.
+-- creates the Lua State and loads standard libraries.
+function lua_State_mt:__new()
+   local vm = C.luaL_newstate()
+   assert(vm ~= nil, "Couldn't allocate new LuaState")
+   C.luaL_openlibs(vm)
+   return vm
+end
+
+
+-- compiles a chunk of code and leaves the resultant function in the stack.
+-- returns self or false and an error message
+function lua_State_mt:load(code, name)
+   if not code then return self end
+
+   if C.luaL_loadbuffer(self, code, #code, '@'..(name or code:match('[^\n]*'))) ~= 0 then
+      local err = ffi.string(C.lua_tolstring(self, -1, nil))
+      self:close()
+      return false, string.format("Error loading %q: %s", name, err)
+   end
+   return self
+end
+
+
+-- pushes several values into the vm stack.
+-- handles only simple values: nil, boolean, numbers (double floats),
+-- strings, tables (only key/values of known types, non-cyclic)
+-- userdata and cdata are pushed as lightuserdata values
+function lua_State_mt:push_values(...)
+   local narg = select('#', ...)
+   local prevtop = C.lua_gettop(self)
+   for i = 1, narg do
+      local v = select(i, ...)
+      local typ = type(v)
+      if typ == 'nil' then
+         C.lua_pushnil(self)
+      elseif typ == 'boolean' then
+         C.lua_pushboolean(self, v)
+      elseif typ == 'number' then
+         C.lua_pushnumber(self, v)
+      elseif typ == 'string' then
+         C.lua_pushlstring(self, v, #v)
+      elseif typ == 'table' then
+         C.lua_createtable(self, 0, 0)
+         for k1, v1 in pairs(v) do
+            self:push_values(k1, v1)
+            C.lua_settable(self, -3)
+         end
+      elseif typ == 'userdata' or typ == 'cdata' then
+         C.lua_pushlightuserdata(self, v)
+      end
+   end
+   return C.lua_gettop(self) - prevtop
+end
+
+-- returns a variable number of values from the stack
+-- of the vm, optinally pops those values.
+-- num (optional): number of values to read.  defaults to all values
+-- keep (optional): boolean flag, if true, keeps the values in the stack
+--  if false, removes the values it reads.
+local pv_sz = ffi.new('size_t[?]', 1)
+function lua_State_mt:pull_values(num, keep)
+   local narg = C.lua_gettop(self)
+   num = num or narg
+   local o = {}
+   for i = narg-num+1, narg do
+      local typ, v = C.lua_type(self, i), nil
+      if typ == C.LUA_TNIL then
+         v = nil
+      elseif typ == C.LUA_TBOOLEAN then
+         v = C.lua_toboolean(self, i) ~= 0
+      elseif typ == C.LUA_TNUMBER then
+         v = C.lua_tonumber(self, i)
+      elseif typ == C.LUA_TSTRING then
+         local buf = C.lua_tolstring(self, i, pv_sz)
+         v = ffi.string(buf, pv_sz[0])
+      elseif typ == C.LUA_TTABLE then
+         v = {}
+         C.lua_pushnil(self)
+         while C.lua_next(self, i) ~= 0 do
+            local k1, v1 = self:pull_values(2, true)
+            v[k1] = v1
+            C.lua_settop(self, -2)
+         end
+      end
+      o[i-narg+num] = v
+   end
+   if not keep then
+      C.lua_settop(self, narg-num)
+   end
+   return unpack(o)
+end
+
+
+-- calls a function in the Lua State.
+-- the first argument should be either:
+--   - the name of a function in the global environment
+--   - nil to call a function in the top of the stack
+-- the rest of the arguments are sent to the function
+-- according to the limitations of push_values().
+-- returns (true, result values) if successful or
+-- (false, error) if any error is raised (similar to standard pcall())
+function lua_State_mt:pcall(fname, ...)
+   if fname ~= nil then
+      C.lua_getfield(self, C.LUA_GLOBALSINDEX, fname)
+   end
+   local prevtop = C.lua_gettop(self)-1
+
+   local nargs, err = self:push_values(...)
+   if not nargs then return nargs, err end
+
+   if C.lua_pcall(self, nargs, C.LUA_MULTRET, 0) ~= 0 then
+      local err = ffi.string(C.lua_tolstring(self, -1, nil))
+      C.lua_settop(self, prevtop)
+      return false, err
+   end
+
+   return true, self:pull_values(C.lua_gettop(self)-prevtop)
+end
+
+
+-- copy the given table into the global space of the vm
+function lua_State_mt:add_globals(t)
+   for k, v in pairs(t) do
+      self:push_values(k, v)
+      C.lua_settable(self, C.LUA_GLOBALSINDEX)
+   end
+end
+
+
+-- disposal function
+function lua_State_mt:close()
+   C.lua_close(self)
+end
+lua_State_mt.__gc = lua_State_mt.close
+
+ffi.metatype(lua_State_t, lua_State_mt)
+
+-- END Lua State handling functions
+-- BEGIN SnabbSwitch app vm wrapper
+
+-- to wrap pcall()-like functions
+-- with return form (bool, ...)
+local function stripassert(ok, ...)
+   return select(2, assert(ok, ...))
+end
+
+
+
+local function new_app_vm()
+   local vm = lua_State_t()
+   vm:add_globals({_shared_packets_fl = _shared_packets_fl})
+   assert(vm:load([[
+      ffi = require('ffi')
+      engine = require('core.app')
+      packet = require('core.packet')
+      link = require('core.link')
+   ]], '[app frame]'))
+   assert(vm:pcall())
+   return vm
+end
+
+
+
+-- returns an array of all global function names in the vm
+local function get_global_functions(vm)
+   return stripassert(vm:load[[
+      -- get global function names
+      local o = {}
+      for k, v in pairs(_G) do
+         if type(v) == 'function' then
+            o[#o+1] = k
+         end
+      end
+      return o
+   ]]:pcall())
+end
+
+-- adds function proxies to the app
+local function make_proxies(app, prevglobals)
+   prevglobals = prevglobals or {}
+   for _, fname in ipairs(prevglobals) do
+      prevglobals[fname] = true
+   end
+   for _, fname in ipairs(get_global_functions(app.vm)) do
+      if not prevglobals[fname] then
+         app[fname] = function(self, ...)
+            return stripassert(self.vm:pcall(fname, ...))
+         end
+      end
+   end
+   return app
+end
+
+-- unwraps the link tables inside the vm
+local function inject_links(app)
+   local vm = app.vm
+   vm:load[[
+      -- setffitable
+      local name, ct, t = ...
+      if type(ct) == 'string' then
+         ct = ffi.typeof(ct)
+      end
+      local o = _G[name] or {}
+      local memo = {}
+      for k,v in pairs(t) do
+         if ct and type(v) == 'userdata' then
+            memo[v] = memo[v] or ffi.cast(ct, v)
+            v = memo[v]
+         end
+         o[k] = v
+      end
+      _G[name] = o
+   ]]
+   C.lua_pushvalue(vm, -1)
+   assert(vm:pcall(nil, 'input', 'struct link *', app.input))
+   assert(vm:pcall(nil, 'output', 'struct link *', app.output))
+end
+
+-- main entry point,
+-- construct the 'class' for the named app module
+local function sandbox_loader(name)
+   return {
+      name = name,
+
+      new = function (self, arg)
+         local vm = new_app_vm()
+         if arg then vm:add_globals(arg) end
+         local prevglobals = get_global_functions(vm)
+         assert(vm:pcall('require', self.name))
+         return make_proxies({
+            vm = vm,
+            name = self.name,
+            zone = self.name,
+            inject_links = inject_links,
+         }, prevglobals)
+      end,
+   }
+end
+
+-- END SnabbSwitch app vm wrapper
+
+return sandbox_loader

--- a/src/core/stats.lua
+++ b/src/core/stats.lua
@@ -1,0 +1,57 @@
+
+local counter = require('lib.ipc.shmem.counter')
+local base = nil
+
+local stats = {}
+
+function stats.new()
+   local cntr = counter:new{filename="free_packet_stats.shmem"}
+   cntr:register('frees', 0)
+   cntr:register('freebytes', 0)
+   cntr:register('freebits', 0)
+   cntr:register('lastfrees', 0)
+   cntr:register('lastfreebytes', 0)
+   cntr:register('lastfreebits', 0)
+   cntr:register('reportedfrees', 0)
+   cntr:register('reportedfreebytes', 0)
+   cntr:register('reportedfreebits', 0)
+   base = cntr:base()
+end
+
+
+function stats.attach()
+   local cntr = counter:attach{filename="free_packet_stats.shmem"}
+   base = cntr:base()
+end
+
+
+function stats.add(p)
+   base[0] = base[0] + 1                                        -- frees
+   base[1] = base[1] + p.length                                 -- freebytes
+   -- Calculate bits of physical capacity required for packet on 10GbE
+   -- Account for minimum data size and overhead of CRC and inter-packet gap
+   base[2] = base[2] + (math.max(p.length, 46) + 4 + 5) * 8     -- freebits
+end
+
+
+function stats.breathe()
+   local newfrees = base[0] - base[3]       -- frees - lastfrees
+   for i = 0, 3 do
+      base[i+3] = base[i]
+   end
+   return newfrees
+end
+
+
+function stats.report()
+   local newfrees = base[0] - base[6]
+   local newbytes = base[1] - base[7]
+   local newbits  = base[2] - base[8]
+   for i = 0, 3 do
+      base[i+6] = base[i]
+   end
+   return newfrees, newbytes, newbits
+end
+
+
+return stats

--- a/src/lib/ipc/shmem/counter.lua
+++ b/src/lib/ipc/shmem/counter.lua
@@ -24,7 +24,7 @@ counter._name = "Counter shared memory"
 counter._namespace = "Counter"
 counter._version = 1
 -- Suppress the length field in the index file
-counter._fs = ''
+-- counter._fs = ''
 counter._ctype = ffi.typeof("uint64_t")
 
 function counter:register (name, value)

--- a/src/lib/ipc/shmem/shmem.lua
+++ b/src/lib/ipc/shmem/shmem.lua
@@ -278,7 +278,7 @@ function shmem:attach (options)
 	 length = tonumber(length)
 	 if o._ctype then
 	    ctype = o._ctype
-	    assert(ffi.sizeof(ctype == length))
+	    assert(ffi.sizeof(ctype) == length)
 	 else
 	    ctype = ffi.typeof("uint8_t [$]", length)
 	 end


### PR DESCRIPTION
A cleaner and less disrupting version of what we've seen on previous 'style proposal' branches.

- There's no 'general purpose' wrapping of the Lua C API, just enough methods to make `sandbox_loader.lua` source readable.

- Doesn't depend on `app.lua` calling `app:relink()`. Instead, adds an explicit `:inject_links()` method.

- Cleaner method to share the packet freelist.

- The `engine.frees`, `.freebytes` and `.freebits` are moved to an `ipc.shmem.counters` file, allowing any sandbox to update it.  It could also be an FFI struct shared in a similar manner to `packet_fl`. In a multithreaded future it could be a per-thread struct, updating the central statistics after each `breath()` cycle.