### PR TITLE
pflua: Upgrade from 13b194e (May 6) to 2752395 (May 26)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ E= @echo
 # Defined here to detect version mismatches at build time.
 LUAJIT_VSN    := "v2.0.3-328-g04dc64b"
 LJSYSCALL_VSN := "v0.10-65-g7081d97"
-PFLUA_VSN     := "13b194e7a214faae5c3d2916a998418fc841dbc2"
+PFLUA_VSN     := "27523953c03745d4c4fbbcf81f676bc774e4329e"
 
 TEST_SKIPPED="43"
 


### PR DESCRIPTION
Changes:

    $ git log --oneline --no-merges 13b194e..2752395
    9b9ad37 Make sure the pcap library is loaded
    3b6e6f5 Fix -O0 flag for pflua-expand tool
    dd4ba88 Improve optimizer performance
    176e4d3 Fix backend quadratic performance
    cbae3b6 Print the libpcap version on pflua-pipeline-match failure.
    335c6db Pflang generator and pure-lua/bpf-lua comparison property
    90a475e Reworded pflua-pipeline-match to say 'concur'
    78e6463 Fixed a test filename typo
    8755366 Added a regression test for bug 130, libpcap failfast
    4343231 Added a regression test for bug 171
    2fcaa9d Added a regression test for reducer bug
    52f7ff4 Reduce >= less aggressively
    36ed701 Accept '!' as logical 'not' operator
    771a789 Fix precedence of logical 'not'
    4bedd66 Hack around fail-fast by returning a 'false' filter instead
    ecc8e40 Fix error message when parsing invalid portrange
    ba26681 Allow IPv4 quads in IPv6 representation
    ec68c28 Make IPv6 address parsing more strict
    6954666 Added regression tests for 131, 'not' broken
    858f1d9 lhoist lifts more length checks in tail position
    1d2cdcf Represent tail continuations in optimize IR
    7a36005 Regression test for bug 129, flipped portranges
    422b71b Added a regression test for bug 139, multi-octet packet access
    2abdc58 Added a regression test for bug120, rangecheck
    af19bae Added a regression test for bug 126
    c4e2059 Refactored pipe* into pflua-pipelines-match
    88f8927 Packet access doesn't abort if the packet is of the wrong type
    7b116bd Guard expressions specify their failure continuation
    0dc8195 Changes from the length-hoisting fix