### PR TITLE
Makefile: Avoid nonportable 'basename -a'

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -191,7 +191,7 @@ $(INCOBJ): obj/%_inc.o: %.inc Makefile program/programs.inc | $(OBJDIR)
 
 # Create list of programs that exist
 program/programs.inc:
-	@ls -1d program/*/ | xargs basename -a > $@
+	@(for d in program/*/; do basename $$d; done) > $@
 
 .FORCE: program/programs.inc
 


### PR DESCRIPTION
`basename -a` seems be a relatively new feature of GNU coreutils that is not available in recent Debian releases.

Resolves #505.