### PR TITLE
core.shm amendments

### DIFF
--- a/src/core/counter.h
+++ b/src/core/counter.h
@@ -1,0 +1,1 @@
+struct counter { uint64_t c; };

--- a/src/core/counter.lua
+++ b/src/core/counter.lua
@@ -31,7 +31,7 @@ local counter_t = ffi.typeof("struct counter")
 
 function open (name, readonly) return shm.map(name, counter_t, readonly) end
 function set  (counter, value) counter.c = value                         end
-function add  (counter, value) counter.c = counter.c + value             end
+function add  (counter, value) counter.c = counter.c + (value or 1)      end
 function read (counter)        return counter.c                          end
 
 function selftest ()

--- a/src/core/counter.lua
+++ b/src/core/counter.lua
@@ -29,10 +29,10 @@ require("core.counter_h")
 
 local counter_t = ffi.typeof("struct counter")
 
-function open (name)          return shm.map(name, counter_t) end
-function set (counter, value) counter.c = value               end
-function add (counter, value) counter.c = counter.c + value   end
-function read (counter)       return counter.c                end
+function open (name, readonly) return shm.map(name, counter_t, readonly) end
+function set  (counter, value) counter.c = value                         end
+function add  (counter, value) counter.c = counter.c + value             end
+function read (counter)        return counter.c                          end
 
 function selftest ()
    print("selftest: core.counter")

--- a/src/core/counter.lua
+++ b/src/core/counter.lua
@@ -25,7 +25,9 @@ module(..., package.seeall)
 
 local shm = require("core.shm")
 local ffi = require("ffi")
-local counter_t = ffi.typeof("struct { uint64_t c; }")
+require("core.counter_h")
+
+local counter_t = ffi.typeof("struct counter")
 
 function open (name)          return shm.map(name, counter_t) end
 function set (counter, value) counter.c = value               end


### PR DESCRIPTION
See https://github.com/lukego/snabbswitch/pull/3

* Expose `struct counter` in `core/counter.h` in order to be able to use it in `link.h` (in my SnabbTop porting branch I let `core.link` increment the shared counters directly (`rxbytes`, ...)
* Allow passing of `readonly` parameter from `counter.open` to `shm.map`
* Make `value` parameter of `counter.add` defaut to 1