### PR TITLE
Upgrade LuaJIT to fe56522 (June 13)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ E= @echo
 
 # Required submodule versions.
 # Defined here to detect version mismatches at build time.
-LUAJIT_VSN    := "v2.0.3-328-g04dc64b"
+LUAJIT_VSN    := "v2.0.4-306-gfe56522"
 LJSYSCALL_VSN := "v0.10-65-g7081d97"
 PFLUA_VSN     := "13b194e7a214faae5c3d2916a998418fc841dbc2"
 


### PR DESCRIPTION
This version has reverted the "table allocation bump optimization" that
is buggy and broke pflua. (Great detective work by the pflua team!)