### PR TITLE
intel10g: Disable DCA relaxed ordering in SF mode

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -378,6 +378,7 @@ function M_sf:init_receive ()
    end
    self:set_receive_descriptors()
    self.r.RXCTRL:set(bits{RXEN=0})
+   self.r.DCA_RXCTRL:clr(bits{RxCTRL=12})
    return self
 end
 


### PR DESCRIPTION
Apply the same DCA settings for SF/PF (Single Function) mode as for VF (Virtual Function) mode. This prevents heavy packet payload corruption on at least one server.

This is a draft fix for the issue [reported by Alex Gall](https://groups.google.com/d/msg/snabb-devel/sP3wJ-8fEEA/O1WMAG96SlQJ) on snabb-devel.

I am not sure the details are exactly right: by my reading of the data sheet this is actually clearing a reserved bit. @javierguerragiraldez what do you think?