### PR TITLE
intel10g: Fix RX DMA corruption in SF mode

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -378,6 +378,11 @@ function M_sf:init_receive ()
    end
    self:set_receive_descriptors()
    self.r.RXCTRL:set(bits{RXEN=0})
+   if self.r.DCA_RXCTRL then -- Register may be undefined in subclass (PF)
+      -- Datasheet 4.6.7 says to clear this bit.
+      -- Have observed payload corruption when this is not done.
+      self.r.DCA_RXCTRL:clr(bits{RxCTRL=12})
+   end
    return self
 end
 


### PR DESCRIPTION
Fix a problem where packet payload could be corrupted on receive on certain hardware. There was an exotic register flag that needs to be cleared and this was taken care of in VF mode (when using VMDq) but not in SF mode (when using a raw NIC). Now both cases work the same.

Reported here:
https://groups.google.com/d/msg/snabb-devel/sP3wJ-8fEEA/O1WMAG96SlQJ

May also resolve a previously reported problem:
https://groups.google.com/forum/#!topic/snabb-devel/MrzImre1gbM

Obsoletes #523.