### PR TITLE
include unistd.h correctly

### DIFF
--- a/src/core/lib.c
+++ b/src/core/lib.c
@@ -2,7 +2,7 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 
 /* Return the current wall-clock time in nanoseconds. */
 uint64_t get_time_ns()


### PR DESCRIPTION
Cherrypicking obviously correct commit from #483 - sys/unistd is not a correct header, in order to reduce the Musl specific diffs.