### PR TITLE
deps/pflua: Upgrade to latest master (5e2c56b)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ E= @echo
 # Defined here to detect version mismatches at build time.
 LUAJIT_VSN    := "v2.0.4-306-gfe56522"
 LJSYSCALL_VSN := "v0.10-65-g7081d97"
-PFLUA_VSN     := "27523953c03745d4c4fbbcf81f676bc774e4329e"
+PFLUA_VSN     := "5e2c56baa0cf1ec471719bac83e2a99c4e2d5495"
 
 TEST_SKIPPED="43"
 


### PR DESCRIPTION
Regularly scheduled monthly update of pflua to the latest version. (Just pulling from the master branch unless/until upstream suggest something else.) Can be reverted or updated before release if needed.

Changes:

```
$ git shortlog --no-merges 275239..5e2c56
Andy Wingo (28):
      Simplify lexer self-tests
      Add address-of pflang extension
      Add parser for "pfmatch" language
      Add "otherwise" test; better comments
      Implement pfmatch expander.
      Add doc/fail-fail.md to test { if foo fail fail } optimization
      More pfmatch language updates.
      Add optimizer support for 'call'
      Fix pfmatch parser for LogicalExpression
      ANF lowering supports "call"
      Add SSA support for tail calls
      Backend supports tail calls
      pfmatch: allow underscores in procedure names
      Add pfmatch documentation
      A couple of doc fixups
      Fix "fail" semantics in pfmatch
      Minor optimization tweaks
      Update pfmatch docs
      Fix pfmatch.md typo
      pflua-compile supports --match
      More uniform treatment of fail, match, and call
      More effective length check hoisting in a boolean context
      Update pfmatch compile output
      Update pfmatch.md with the actual matcher, not a test
      Better lift repeated tests into dominating positions
      Better code generation for calls
      Remove duplicated simplify_if clause
      Renumber ANF-generated vars for readability

Diego Pino Garcia (1):
      Cleanup of function passed to 'memoize'.

Katerina Barone-Adesi (2):
      Generate 'ether' clauses, and IPv6 addresses and netmasks.
      Recognize the contributions of Peter Melnichenko in the README

mpeterv (7):
      Fold associative binops more aggresively
      Simplify 'if A fail fail' to 'fail'
      Only lex addresses when necessary
      Reject hexadecimal port numbers in portrange
      Remove duplicated IPv4 parsing
      Allow octal literals as arguments
      Accept hostnames starting with large integers
```