### PR TITLE
packetblaster: Fix TX starvation bug

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -89,13 +89,6 @@ For example: Move packets from input ports to output ports or to a
 network adapter.
 
 
-— Method **myapp:relink**
-
-*Optional*. React to a changes in input/output links (`app.input` and
-`app.output`). This method is called after a link reconfiguration but
-before the next packets are processed.
-
-
 — Method **myapp:reconfig** *arg*
 
 *Optional*. Reconfigure the app with a new *arg*. If this method is not
@@ -207,7 +200,23 @@ following keys are recognized:
 Returns monotonic time in seconds as a floating point number. Suitable
 for timers.
 
+— Variable **engine.busywait**
 
+If set to true then the engine polls continuously for new packets to
+process. This consumes 100% CPU and makes processing latency less
+vulnerable to kernel scheduling behavior which can cause pauses of
+more than one millisecond.
+
+Default: false
+
+— Variable **engine.Hz**
+
+Frequency at which to poll for new input packets. The default value is
+'false' which means to adjust dynamically up to 100us during low
+traffic. The value can be overridden with a constant integer saying
+how many times per second to poll.
+
+This setting is not used when engine.busywait is true.
 
 ## Link (core.link)
 

--- a/src/README.md.src
+++ b/src/README.md.src
@@ -216,7 +216,23 @@ following keys are recognized:
 Returns monotonic time in seconds as a floating point number. Suitable
 for timers.
 
+— Variable **engine.busywait**
 
+If set to true then the engine polls continuously for new packets to
+process. This consumes 100% CPU and makes processing latency less
+vulnerable to kernel scheduling behavior which can cause pauses of
+more than one millisecond.
+
+Default: false
+
+— Variable **engine.Hz**
+
+Frequency at which to poll for new input packets. The default value is
+'false' which means to adjust dynamically up to 100us during low
+traffic. The value can be overridden with a constant integer saying
+how many times per second to poll.
+
+This setting is not used when engine.busywait is true.
 
 ## Link (core.link)
 

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -55,6 +55,10 @@ Hz = false
 sleep = 0
 maxsleep = 100
 
+-- busywait: If true then the engine will poll for new data in a tight
+-- loop (100% CPU) instead of sleeping according to the Hz setting.
+busywait = false
+
 -- Return current monotonic time in seconds.
 -- Can be used to drive timers in apps.
 monotonic_now = false
@@ -233,7 +237,7 @@ function main (options)
    repeat
       breathe()
       if not no_timers then timer.run() end
-      pace_breathing()
+      if not busywait then pace_breathing() end
    until done and done()
    if not options.no_report then report(options.report) end
 end

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -4,6 +4,7 @@ local engine    = require("core.app")
 local config    = require("core.config")
 local timer     = require("core.timer")
 local pci       = require("lib.hardware.pci")
+local intel10g  = require("apps.intel.intel10g")
 local intel_app = require("apps.intel.intel_app")
 local basic_apps = require("apps.basic.basic_apps")
 local main      = require("core.main")
@@ -45,6 +46,8 @@ function run (args)
          config.link(c, "tee."..tostring(nics).."->"..name..".input")
       end
    end
+   engine.busywait = true
+   intel10g.num_descriptors = 32*1024
    engine.configure(c)
    local fn = function ()
                  print("Transmissions (last 1 sec):")

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -1,6 +1,6 @@
 module(..., package.seeall)
 
-local app       = require("core.app")
+local engine    = require("core.app")
 local config    = require("core.config")
 local timer     = require("core.timer")
 local pci       = require("lib.hardware.pci")
@@ -45,15 +45,15 @@ function run (args)
          config.link(c, "tee."..tostring(nics).."->"..name..".input")
       end
    end
-   app.configure(c)
+   engine.configure(c)
    local fn = function ()
                  print("Transmissions (last 1 sec):")
-                 app.report_each_app()
+                 engine.report_each_app()
               end
    local t = timer.new("report", fn, 1e9, 'repeating')
    timer.activate(t)
-   if duration then app.main({duration=duration})
-   else             app.main() end
+   if duration then engine.main({duration=duration})
+   else             engine.main() end
 end
 
 function is_device_suitable (pcidev, patterns)


### PR DESCRIPTION
Fix a performance regression bug: packetblaster peaked at around 3 Mpps because the default TX ring size has shrunk. Now sends more aggressively (around 12.8 Mpps on Interlaken).

The packet rate should actually be higher for 64-byte packets but that is another matter. This change fixes the specific regression.

See also #547 and #530.