### PR TITLE
vhost.h, vhost_user.h: Use more explicit types

### DIFF
--- a/src/apps/vhost/vhost.h
+++ b/src/apps/vhost/vhost.h
@@ -45,12 +45,13 @@ struct vhost {
 // Below are structures imported from Linux headers.
 // This is purely to avoid a compile-time dependency on those headers,
 // which has been an problem on certain development machines.
-struct vhostu_vring_state { unsigned int index, num; };
-struct vhostu_vring_file { unsigned int index; int fd; };
+struct vhostu_vring_state { 
+  uint32_t index, num;
+} __attribute__((packed));
 struct vhostu_vring_addr {
-  unsigned int index, flags;
+  uint32_t index, flags;
   uint64_t desc_user_addr, used_user_addr, avail_user_addr, log_guest_addr;
-};
+} __attribute__((packed));
 
 // These were printed out with a little throw-away C program.
 enum {

--- a/src/apps/vhost/vhost_user.h
+++ b/src/apps/vhost/vhost_user.h
@@ -43,7 +43,7 @@ enum {
 };
 
 struct vhost_user_msg {
-    int request;
+    uint32_t request;
     uint32_t flags;
     uint32_t size;
     union {


### PR DESCRIPTION
Switch to stricter C declarations to ensure that the memory layout of vhost-user requests matches the vhost-user specification. For example, use 'uint32_t' instead of 'unsigned int'. Add __attribute__((packed)) to struct declarations.

This is to ensure that the on-the-wire memory layout follows the vhost-user spec rather than the C compiler. Inspired by #560 and *may conceivably* be helpful there.

vhost-user spec:
https://github.com/qemu/qemu/blob/master/docs/specs/vhost-user.txt