### PR TITLE
Add 'snsh -p' argument to run a different program

### DIFF
--- a/src/program/snsh/README
+++ b/src/program/snsh/README
@@ -7,6 +7,7 @@ Execute SCRIPT if specified and then exit.
   -i,        --interactive   Start an interactive Read-Eval-Print Loop.
   -e EXPR,   --eval EXPR     Evaluate the Lua expression EXPR.
   -l MODULE, --load MODULE   Load (require) the Lua module MODULE.
+  -p PROG,   --program PROG  Run the program PROG instead of snsh.
   -t MODULE, --test MODULE   Test (selftest) the Lua module MODULE.
   -d,        --debug         Enable additional debugging checks.
   -j CMD,    --jit CMD       Control LuaJIT behavior. Available commands:

--- a/src/program/snsh/snsh.lua
+++ b/src/program/snsh/snsh.lua
@@ -7,6 +7,7 @@ local long_opts = {
    ["package-path"] = "P",
    eval = "e",
    load = "l",
+   program = "p",
    test = "t",
    interactive = "i",
    debug = "d",
@@ -18,12 +19,14 @@ function run (parameters)
    local profiling = false
    local start_repl = false
    local noop = true -- are we doing nothing?
+   local program -- should we run a different program?
    -- Table of functions implementing command-line arguments
    local opt = {}
    function opt.h (arg) print(usage) main.exit(0)            end
    function opt.l (arg) require(arg)            noop = false end
    function opt.t (arg) require(arg).selftest() noop = false end
    function opt.d (arg) _G.developer_debug = true            end
+   function opt.p (arg) program = arg                        end
    function opt.i (arg) start_repl = true       noop = false end
    function opt.j (arg)
       if arg:match("^v") then
@@ -51,9 +54,12 @@ function run (parameters)
    end
 
    -- Execute command line arguments
-   parameters = lib.dogetopt(parameters, opt, "hl:t:die:j:P:", long_opts)
+   parameters = lib.dogetopt(parameters, opt, "hl:p:t:die:j:P:", long_opts)
 
-   if #parameters > 0 then
+   if program then
+      local mod = (("program.%s.%s"):format(program, program))
+      require(mod).run(parameters)
+   elseif #parameters > 0 then
       run_script(parameters)
    elseif noop then
       print(usage)


### PR DESCRIPTION
Support using `snsh` as an entry point to any snabb program. This way you can use snsh for pre-execution configuration such as enabling profiling or JIT tracing.

Here is an example of running `snabbmark` after enabling profiling:

    $ sudo ./snabb snsh -jp=3F -p snabbmark basic1 1e6

    Processed 1.1 million packets in 0.09 seconds (rate: 12.7 Mpps).
    25%  link.lua:full < link.lua:transmit < basic_apps.lua:method
    13%  freelist.lua:freelist_add < packet.lua:free_internal < packet.lua:free
    13%  freelist.lua:allocate < packet.lua:clone < basic_apps.lua:method
    13%  packet.lua:free < basic_apps.lua:method < app.lua:with_restart
    13%  link.lua:receive < basic_apps.lua:method < app.lua:with_restart
    13%  packet.lua:clone < basic_apps.lua:method < app.lua:with_restart
    13%  app.lua:breathe < app.lua:main < snabbmark.lua:basic1