### PR TITLE
core.counter: Add double-buffering

### DIFF
--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -5,6 +5,7 @@ local lib    = require("core.lib")
 local link   = require("core.link")
 local config = require("core.config")
 local timer  = require("core.timer")
+local counter = require("core.counter")
 local top    = require("lib.ipc.shmem.top")
 local fs     = require("lib.ipc.fs")
 local zone   = require("jit.zone")
@@ -302,6 +303,7 @@ function breathe ()
       end
       firstloop = false
    until not progress  -- Stop after no link had new data
+   counter.publish()
    breaths = breaths + 1
 end
 


### PR DESCRIPTION
This is primarily intended to avoid a performance problem discovered on PR #558 where frequently accessing many public counter objects is expensive because their addresses are page-aligned and this clashes with the set-associative L1/L2 cache on the Xeon.

Double buffering is a handy technique though and it could become useful in the future for publishing structured shared memory objects and supporting atomic reads.