### PR TITLE
core.link: Streamline counters [DRAFT]

### DIFF
--- a/src/core/link.h
+++ b/src/core/link.h
@@ -12,7 +12,9 @@ struct link {
   // Two cursors:
   //   read:  the next element to be read
   //   write: the next element to be written
-  int read, write;
+  int64_t read, write;
+  // How many packets have been dropped due to ring overflow?
+  int64_t dropped;
   // Index (into the Lua app.active_apps array) of the app that
   // receives from this link.
   int receiving_app;


### PR DESCRIPTION
Reduce the amount of counter-related code and data in `struct link`.

The ring indexes (read, write) and now upgraded to 64-bit integers that do not wrap around [*]. This means that we don't need to use separate packet tx/rx counters because the ring indexes serve that purpose directly. (We do have to be careful to handle wrap-around when actually looking up elements in the ring based on the index.)

The byte counters are simply removed. Do we really need them? (How about if we tracked only packets-per-second plus perhaps a system-wide average packet size?)

Dropped packets are still counted directly because this is important information and I don't immediately see a way to derive it indirectly.

[*] 64-bit packet counters really should not wrap around. Even at one billion packets per second it would take more than 500 years. However, if this is not a safe assumption then we could detect wrap around and account for it on the counters.

(Google: "2^64/(1 billion per second)" => "584.554531 years".)

@eugeneia @javierguerragiraldez @alexandergall what do you guys thing about this idea? I mean in terms of information loss, impact on the code, and conflicts with other open PRs?