### PR TITLE
Speed up Murmur hash functions

### DIFF
--- a/src/lib/hash/base.lua
+++ b/src/lib/hash/base.lua
@@ -38,36 +38,47 @@ local ffi = require("ffi")
 local hash = subClass(nil)
 hash._name = "hash function"
 
+-- Cache for ctypes that store the result of a hash function, keyed by
+-- the size of the result in bytes.  Note: this is not just to save
+-- space but make sure that each instance of the same hash function
+-- uses the exact same ctype (i.e. same internal ctype ID).
+-- Otherwise, it may happen that a trace takes a side exit due to a
+-- ctype mismatch.
+local hash_types = {}
+
 function hash:new ()
    assert(self ~= hash, "Can't instantiate abstract class hash")
    local o = hash:superClass().new(self)
    assert(o._size and o._size >= 32 and o._size%32 == 0)
-   local h_t
-   if o._size >= 64 and o._size%64 == 0 then
-      h_t = ffi.typeof([[
-         union {
-            uint8_t  u8[$];
-            int8_t   u8[$];
-            uint32_t u32[$];
-            int32_t  i32[$];
-            uint64_t u64[$];
-            int64_t  i64[$];
-         }
-      ]],
-      o._size/8, o._size/8,
-      o._size/32, o._size/32,
-      o._size/64, o._size/64)
-   else
-      h_t = ffi.typeof([[
-         union {
-            uint8_t  u8[$];
-            int8_t  u8[$];
-            uint32_t u32[$];
-            int32_t  i32[$];
-         }
-      ]],
-      o._size/8, o._size/8,
-      o._size/32, o._size/32)
+   local h_t = hash_types[o._size]
+   if not h_t then
+      if o._size >= 64 and o._size%64 == 0 then
+         h_t = ffi.typeof([[
+           union {
+              uint8_t  u8[$];
+              int8_t   u8[$];
+              uint32_t u32[$];
+              int32_t  i32[$];
+              uint64_t u64[$];
+              int64_t  i64[$];
+           }
+         ]],
+            o._size/8, o._size/8,
+            o._size/32, o._size/32,
+            o._size/64, o._size/64)
+      else
+         h_t = ffi.typeof([[
+           union {
+             uint8_t  u8[$];
+             int8_t  u8[$];
+             uint32_t u32[$];
+             int32_t  i32[$];
+           }
+         ]],
+            o._size/8, o._size/8,
+            o._size/32, o._size/32)
+      end
+      hash_types[o._size] = h_t
    end
    o.h = h_t()
    return o

--- a/src/lib/hash/base.lua
+++ b/src/lib/hash/base.lua
@@ -56,7 +56,7 @@ function hash:new ()
          h_t = ffi.typeof([[
            union {
               uint8_t  u8[$];
-              int8_t   u8[$];
+              int8_t   i8[$];
               uint32_t u32[$];
               int32_t  i32[$];
               uint64_t u64[$];
@@ -70,7 +70,7 @@ function hash:new ()
          h_t = ffi.typeof([[
            union {
              uint8_t  u8[$];
-             int8_t  u8[$];
+             int8_t   i8[$];
              uint32_t u32[$];
              int32_t  i32[$];
            }


### PR DESCRIPTION
Performance of lib.hash.murmur is improved by reducing the number of
memory accesses to process the "tail" portion of the data.  Current
benchmarks indicate that a pass over a 6-byte value (e.g. an Ethernet
MAC address) takes about 15 CPU cycles with MurmurHash3_x64_128 and
about 19 cycles with MurmurHash3_x86_32, provided that all constants
are pre-loaded into registers.

The base class is changed to make sure that the same CTYPE is used for
allocating the storage that holds the result of a hash function.  The
previous code, which generated distinct CTYPEs, lead to subtle
performance issues due to side-exits being taken in compiled code when
CTYPE-checking guarded instructions failed.