### PR TITLE
Makefile "clean" fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,5 +69,6 @@ check_syscall:
 clean:
 	(cd deps/luajit && $(MAKE) clean)
 	(cd src; $(MAKE) clean; rm -rf syscall.lua syscall)
+	(rm deps/*.vsn)
 
 .SERIAL: all


### PR DESCRIPTION
The files `deps/*.vsn` have to be removed or else the dependencies may not be rebuilt.