### PR TITLE
src/Makefile: Add 'make submods'

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -71,13 +71,9 @@ snabb: $(LUAOBJ) $(PFLUAOBJ) $(HOBJ) $(COBJ) $(ARCHOBJ) $(ASMOBJ) $(INCOBJ) $(LU
 	    echo "pflua:"						>&2; \
 	    echo "  require: $(PFLUA_VSN)"				>&2; \
 	    echo "  found:   $(shell cat ../deps/pflua.vsn) "		>&2; \
-	    echo "Please update and rebuild submodules."		>&2; \
-	    echo ""							>&2; \
-	    echo "Cheat sheet:"						>&2; \
-	    echo "  cd snabbswitch"					>&2; \
-	    echo "  git submodule update"				>&2; \
-	    echo "  make clean"						>&2; \
-	    echo "  make -j"						>&2; \
+	    echo ""                                                     >&2; \
+	    echo "Please update your submodules like this:"             >&2; \
+	    echo "  make submods"                                       >&2; \
 	    echo ""							>&2; \
 	    exit 1; \
 	 fi
@@ -90,6 +86,10 @@ snabb: $(LUAOBJ) $(PFLUAOBJ) $(HOBJ) $(COBJ) $(ARCHOBJ) $(ASMOBJ) $(INCOBJ) $(LU
 	@ls -sh snabb
 
 all: $(EXE)
+
+# Rebuild after git submodules are updated.
+submods:
+	(cd ..; git submodule update; make clean; make)
 
 $(EXE): snabb
 	$(E) "PROGRAM   $@"


### PR DESCRIPTION
This target updates and rebuilds the required git submodules. The Makefile tells you to run this when it detects that the submodule versions are not in sync with the source code.

This is a more streamlined version of the previous behavior where the Makefile would suggest running a series of commands to update you submodules. Now 'make submods' has the same effect.

Fixes #584.