### PR TITLE
core.memory: Catch SIGSEGV to map DMA memory [PoC]

### DIFF
--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -2,3 +2,4 @@ int      lock_memory();
 void    *allocate_huge_page(int size);
 uint64_t phys_page(uint64_t virt_page);
 
+void setup_signal();

--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -116,3 +116,7 @@ function selftest (options)
    print("HugeTLB page allocation OK.")
 end
 
+print("Installing SIGSEGV handler")
+C.setup_signal()
+
+

--- a/src/s1
+++ b/src/s1
@@ -1,0 +1,7 @@
+x = core.memory.dma_alloc(100)
+print("address", x)
+while true do
+  print("current value = " .. x[0])
+  require("ffi").C.usleep(1e6)
+end
+

--- a/src/s2
+++ b/src/s2
@@ -1,0 +1,6 @@
+addr, value = unpack(core.main.parameters)
+print(addr,value)
+print("Setting "..addr.." to "..value)
+io.flush()
+ptr = require("ffi").cast("char*", tonumber(addr))
+ptr[0] = tonumber(value)


### PR DESCRIPTION
This is a quick and dirty proof-of-concept hack done to support SnabbCo/snabbswitch#565 (multicore tests):

Extend core.memory so that the virtual addresses of all packets are
valid in all Snabb Switch processes. The memory allocated by
memory.dma_alloc() is treated specially: if another process tries to
access it then this triggers a SIGSEGV handler that will detect which
memory is needed and automatically map it into the process.

Two simple test scripts are provided: s1 that allocates memory and s2
that modifies it without any explicit mapping.

Run like this:

    $ sudo ./snabb snsh s1
    Installing SIGSEGV handler
    address cdata<char *>: 0x5009f7c00000
    current value = 0
    current value = 0
    current value = 0
    ...

Then use the same address to change the value with s2 that simply
converts it to a pointer and pokes it:

    $ make && sudo strace  ./snabb snsh s2 0x5009f7c00000 42

and now you see the new value in s1:

    current value = 42

This is really quick and dirty! I will clean it up if it works and we decide to keep it.

cc @javierguerragiraldez 