### PR TITLE
snabbnfv traffic: Added -b/--busy option

### DIFF
--- a/src/program/snabbnfv/traffic/README
+++ b/src/program/snabbnfv/traffic/README
@@ -10,6 +10,8 @@ snabbnfv traffic [OPTIONS] <pci-address> <config-file> <socket-path>
                              Print a debug report every SECONDS.
 			     The debug report includes a NIC register dump.
 			     Default: 600s (10 minutes)
+  -b, --busy                 Run in a busy-loop without sleeping.
+                             This minimizes latency but consumes 100% CPU.
   -B NPACKETS, --benchmark NPACKETS
                              Benchmark processing NPACKETS.
   -h, --help

--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -15,6 +15,7 @@ local long_opts = {
    ["link-report-interval"] = "k",
    ["load-report-interval"] = "l",
    ["debug-report-interval"] = "D",
+   ["busy"] = "b",
    ["long-help"] = "H"
 }
 
@@ -30,7 +31,8 @@ function run (args)
    function opt.k (arg) linkreportinterval = tonumber(arg) end
    function opt.l (arg) loadreportinterval = tonumber(arg) end
    function opt.D (arg) debugreportinterval = tonumber(arg) end
-   args = lib.dogetopt(args, opt, "hHB:k:l:D:", long_opts)
+   function opt.b (arg) engine.busywait = true              end
+   args = lib.dogetopt(args, opt, "hHB:k:l:D:b", long_opts)
    if #args == 3 then
       local pciaddr, confpath, sockpath = unpack(args)
       local ok, info = pcall(pci.device_info, pciaddr)


### PR DESCRIPTION
The new `snabbnfv traffic --busy` (`-b`) option makes the traffic process run in a busy-loop.

This minimizes latency but always consumes 100% CPU.