### PR TITLE
deps/luajit: Switch to own snabb branch

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ E= @echo
 
 # Required submodule versions.
 # Defined here to detect version mismatches at build time.
-LUAJIT_VSN    := "v2015.08-snabb"
+LUAJIT_VSN    := "v2.0.4-306-gfe56522"
 LJSYSCALL_VSN := "v0.10-65-g7081d97"
 PFLUA_VSN     := "5e2c56baa0cf1ec471719bac83e2a99c4e2d5495"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ E= @echo
 
 # Required submodule versions.
 # Defined here to detect version mismatches at build time.
-LUAJIT_VSN    := "v2.0.4-306-gfe56522"
+LUAJIT_VSN    := "v2.0.4-330-g5feb63a"
 LJSYSCALL_VSN := "v0.10-65-g7081d97"
 PFLUA_VSN     := "5e2c56baa0cf1ec471719bac83e2a99c4e2d5495"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ E= @echo
 
 # Required submodule versions.
 # Defined here to detect version mismatches at build time.
-LUAJIT_VSN    := "v2.0.4-306-gfe56522"
+LUAJIT_VSN    := "v2015.08-snabb"
 LJSYSCALL_VSN := "v0.10-65-g7081d97"
 PFLUA_VSN     := "5e2c56baa0cf1ec471719bac83e2a99c4e2d5495"
 


### PR DESCRIPTION
The new upstream source for the LuaJIT submodule is the 'snabb' branch at:
  http://github.com/SnabbCo/luajit

This submodule update includes the latest fixes from Mike's v2.1 branch and also these new extensions:

1. SnabbCo/luajit#5: Support profiling at trace granularity.
2. SnabbCo/luajit#6: Support for perf events to drive the profiler.

These are extensions that have been used by Snabb developers in the past and are now made available by default.

This is motivated in part by Mike Pall encouraging the community to take over development and maintenance of LuaJIT:
https://groups.google.com/d/msg/snabb-devel/CgZEDWfIyo8/t_Q5WdsZCgAJ