### PR TITLE
branches.md: Remove obsolete lukego/nfv branch

### DIFF
--- a/src/doc/branches.md
+++ b/src/doc/branches.md
@@ -48,13 +48,6 @@ The current state of each branch with respect to master is visible here:
     
     Maintainer: Max Rottenkolber <max@mr.gy>
 
-#### nfv
-    
-    BRANCH: nfv git://github.com/lukego/snabbswitch
-    snabbnfv application development branch.
-    
-    Maintainer: Luke Gorrie <luke@snabb.co>
-
 #### vpn
     
     BRANCH: vpn git://github.com/alexandergall/snabbswitch


### PR DESCRIPTION
Remove the lukego/nfv branch.

My Snabb NFV development is currently targeted at the master branch. In the future I am interested in having a larger network of NFV-related branches, e.g. a long term stable branch, but that can be added later in cooperation with other interested people.