### PR TITLE
lib.pci: Support Intel X540 with intel_app

### DIFF
--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -56,6 +56,7 @@ function which_driver (vendor, device)
    if vendor == '0x8086' then
       if device == '0x10fb' then return 'apps.intel.intel_app' end -- Intel 82599
       if device == '0x10d3' then return 'apps.intel.intel_app' end -- Intel 82574L
+      if device == '0x1528' then return 'apps.intel.intel_app' end -- Intel X540
       if device == '0x105e' then return 'apps.intel.intel_app' end -- Intel 82571
    elseif vendor == '0x1924' then
       if device == '0x0903' then return 'apps.solarflare.solarflare' end


### PR DESCRIPTION
Recognize the PCI ID of the Intel X540 controller and map it to the intel_app.

This is somewhat experimental: the X540 is a new Ethernet controller that is supposed to be compatible with 82599 but we don't have much experience yet.

Based on this snabb-devel post by Chaitanya Lala:
https://groups.google.com/forum/#!topic/snabb-devel/tT_SfXMNxxI