### PR TITLE
OOP style for packet and link FFI structs

### DIFF
--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -123,3 +123,13 @@ function selftest ()
    print("selftest OK")
 end
 
+ffi.metatype('struct link', {__index = {
+   receive = receive,
+   front = front,
+   transmit = transmit,
+   empty = empty,
+   full = full,
+   nreadable = nreadable,
+   nwritable = nwritable,
+   stats = stats,
+}})

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -109,3 +109,12 @@ function preallocate_step()
    packet_allocation_step = 2 * packet_allocation_step
 end
 
+ffi.metatype(packet_t, {__index = {
+   clone = clone,
+   append = append,
+   prepend = prepend,
+   shiftleft = shiftleft,
+   free = free,
+   data = data,
+   length = length,
+}})


### PR DESCRIPTION
Many moons ago it was shown that OOP-style `ffi.metatype()` methods are just as fast as locally caching module functions like `local l_empty = link.empty` without the extra red tape and less risk of sub-par performance just because of wrongly guessing the impact of any given function.

This PR includes the methods for packet and link structs, and converts the `basic_apps` and `keyed_ipv6_tunnel` as examples.