### PR TITLE
Makefile: Shrink 'snabb' from 2MB to 0.6MB with UPX

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -92,9 +92,11 @@ all: $(EXE)
 submods:
 	(cd ..; git submodule update; make clean; make)
 
-$(EXE): snabb
-	$(E) "PROGRAM   $@"
-	$(Q) install -D snabb $@
+$(EXE): snabb bin
+	$(E) "COMPRESS  $@"
+	$(Q) upx -f --brute -o$@ snabb
+	@echo -n "BINARY    "
+	@ls -sh $@
 
 markdown: $(RMOBJS)
 


### PR DESCRIPTION
Snabb Switch is supposed to compile to a 1MB binary but recent
releases have grown to 2MB. This happened gradually as we added a lot
of valuable extensions: pflua, ljsyscall, Intel CPU PMU definitions,
and more built-in programs. This is all fine and good but we ought to
get back within our budget.

This change addresses that with UPX whole-program compression:
http://upx.sourceforge.net/

The normal way to build Snabb Switch (./snabb) is not affected:

    $ make
    ...
    BINARY    2.0M snabb

but you can use other Makefile targets to create (compressed) binaries
for distribution. The targets are bin/snabb, bin/snsh,
bin/packetblaster, and so on for each available program:

    $ make bin/snabb
    ...
    BINARY    608K bin/snabb

This requires upx to be installed. On Ubuntu 'apt-get install upx'.

The release binaries are all functionally identical to ./snabb. The
only difference is that they are smaller, they take about 10 seconds
to build (compression step), and they take about 70 milliseconds
longer to start. There are probably some other side-effects too, like
not playing so well with tools like gdb and perf, but I hope these
will be acceptable (particularly since the binaries used for
development will not be compressed).

This way we can embed easy-to-compress data in Snabb Switch with a
clear conscience and we have nearly 40% of our binary code size budget
available.

This is the same kind of trick that people traditionally use to deal
with fixed space constraints e.g. to deploy a firmware on a 1MB flash
chip or a game on a 1.44MB floppy disk.

See also SnabbCo/luajit#7.