### PR TITLE
appbench: Detailed per-app performance analysis [WIP]

### DIFF
--- a/src/apps/keyed_ipv6_tunnel/tunnel.lua
+++ b/src/apps/keyed_ipv6_tunnel/tunnel.lua
@@ -174,11 +174,11 @@ end
 
 function SimpleKeyedTunnel:push()
    -- encapsulation path
+
    local l_in = self.input.decapsulated
    local l_out = self.output.encapsulated
-   assert(l_in and l_out)
 
-   while not link.empty(l_in) and not link.full(l_out) do
+   while (l_in and l_out) and not link.empty(l_in) and not link.full(l_out) do
       local p = link.receive(l_in)
       packet.prepend(p, self.header, HEADER_SIZE)
       local plength = ffi.cast(plength_ctype, p.data + LENGTH_OFFSET)
@@ -189,8 +189,7 @@ function SimpleKeyedTunnel:push()
    -- decapsulation path
    l_in = self.input.encapsulated
    l_out = self.output.decapsulated
-   assert(l_in and l_out)
-   while not link.empty(l_in) and not link.full(l_out) do
+   while (l_in and l_out) and not link.empty(l_in) and not link.full(l_out) do
       local p = link.receive(l_in)
       -- match next header, cookie, src/dst addresses
       local drop = true

--- a/src/lib/pmu.lua
+++ b/src/lib/pmu.lua
@@ -209,7 +209,7 @@ function setup (patterns)
       local EN = bit.lshift(1, 22)
       writemsr(0, 0x186+n, bit.bor(0x10000, USR, EN, code))
    end
-   enabled = {"instructions", "cycles", "ref-cycles"}
+   enabled = {"instructions", "cycles", "ref_cycles"}
    for i = 1, #set do table.insert(enabled, set[i]) end
    return ndropped
 end
@@ -226,11 +226,15 @@ function writemsr (cpu, msr, value)
 end
 
 -- API function (see above)
-function report (set, aux)
+function report (tab, aux)
    aux = aux or {}
-   local names = lib.array_copy(enabled)
-   local values = {}
-   for i = 0, #names-1 do table.insert(values, tonumber(set[i])) end
+   local data = {}
+   for k,v in pairs(tab) do  table.insert(data, {k=k,v=v})  end
+   -- Sort fixed-purpose counters to come first in definite order
+   local fixed = {cycles='0', ref_cycles='1', instructions='2'}
+   table.sort(data, function(x,y)
+                       return (fixed[x.k] or x.k) < (fixed[y.k] or y.k)
+                    end)
    local auxnames, auxvalues = {}, {}
    for k,v in pairs(aux) do 
       table.insert(auxnames,k) 
@@ -244,14 +248,13 @@ function report (set, aux)
    print()
    -- include aux values in results
    for i = 1, #auxnames do
-      table.insert(names, auxnames[i])
-      table.insert(values, auxvalues[i])
+      table.insert(data, {k=auxnames[i], v=auxvalues[i]})
    end
    -- print values
-   for i = 1, #names do
-      io.write(("%-40s %14s"):format(names[i], core.lib.comma_value(values[i])))
+   for i = 1, #data do
+      io.write(("%-40s %14s"):format(data[i].k, core.lib.comma_value(data[i].v)))
       for j = 1, #auxnames do
-         io.write(("%12.3f"):format(tonumber(values[i]/auxvalues[j])))
+         io.write(("%12.3f"):format(tonumber(data[i].v/auxvalues[j])))
       end
       print()
    end
@@ -274,7 +277,7 @@ function profile (f,  events, aux, quiet)
    switch_to(set)
    local res = f()
    switch_to(nil)
-   if not quiet then report(set, aux) end
+   if not quiet then report(to_table(set), aux) end
    return res
 end
 

--- a/src/lib/pmu_x86.dasl
+++ b/src/lib/pmu_x86.dasl
@@ -24,11 +24,15 @@ local dasm = require("dasm")
 
 local gen = {}
 
+-- Table keeping machine code alive to the GC.
+local anchor = {}
+
 -- Utility: assemble code and optionally dump disassembly.
 function assemble (name, prototype, generator)
    local Dst = dasm.new(actions)
    generator(Dst)
    local mcode, size = Dst:build()
+   table.insert(anchor, mcode)
    if debug then
       print("mcode dump: "..name)
       dasm.dump(mcode, size)

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -250,10 +250,14 @@ events = {"mem_load_uops_retired.l1_hit",
           "mem_load_uops_retired.l3_miss",
           "br_misp_retired.all_branches$"}
 
-function appbench (mod, app, configstring)
-   print("module: " .. mod)
-   print("app:    " .. app)
-   print("config: " .. (configstring or ''))
+function appbench (mod, app, configstring, inlink, outlink)
+   print("module:  " .. mod)
+   print("app:     " .. app)
+   print("config:  " .. (configstring or ''))
+   print("inlink:  " .. (inlink or '[default: rx]'))
+   print("outlink: " .. (outlink or '[default: tx]'))
+   inlink  = inlink  or 'rx'
+   outlink = outlink or 'tx'
    local cfg = configstring and core.lib.load_string(configstring)()
    print(mod, app, cfg)
    local pmu = require("lib.pmu")
@@ -277,10 +281,10 @@ function appbench (mod, app, configstring)
    engine.configure(config.new())
    local c1 = config.new()
    config.app(c1, "source", basic_apps.Source)
-   config.app(c1, "tee",    require(mod)[app], cfg)
+   config.app(c1, "app",    require(mod)[app], cfg)
    config.app(c1, "sink",   basic_apps.Sink)
-   config.link(c1, "source.tx->tee.rx")
-   config.link(c1, "tee.tx->sink.rx")
+   config.link(c1, "source.tx->app."..inlink)
+   config.link(c1, "app."..outlink.."->sink.rx")
    engine.configure(c1)
    print("\nstarting production run...")
    local _, t1 = pmu.measure(run, events)


### PR DESCRIPTION
This is an experimental idea to use the CPU PMU support (#597) to measure the performance impact of introducing a new segment into an app network. This proof-of-concept implementation measures the performance of a reference app network (`Source->Sink`) and then measures the increase caused by extending the app network (`Source->[myapp]->Sink`).

The result printed estimates the impact of the app on metrics such as cycles per packet, L1/L2/L3 cache accesses per packet, and branch mispredictions per packet.

The app to introduce is given using a minimal command-line syntax:

```
snabbmark appbench <module> <app> <config> <in-link> <out-link>
```

For example here is the full output when measuring the `Tee` app. Three sets of results are printed: the reference app network (`Source->Sink`), the production app network (`Source->Tee->Sink`), and the delta of the two (`->Tee->`):

```
$ sudo taskset -c 0 ./snabb snabbmark appbench apps.basic.basic_apps Tee

reference result:
EVENT                                             TOTAL     /packet
cycles                                    4,926,970,014      49.270
ref_cycles                                3,697,570,944      36.976
instructions                             11,313,124,384     113.131
br_misp_retired.all_branches                  1,992,849       0.020
mem_load_uops_retired.l1_hit              3,406,962,877      34.070
mem_load_uops_retired.l2_hit                134,519,317       1.345
mem_load_uops_retired.l3_hit                    589,529       0.006
mem_load_uops_retired.l3_miss                         0       0.000
packet                                      100,000,000       1.000

starting production run...
production result:
EVENT                                             TOTAL     /packet
cycles                                    6,336,783,312      63.368
ref_cycles                                4,754,010,960      47.540
instructions                             15,171,830,862     151.718
br_misp_retired.all_branches                  2,354,542       0.024
mem_load_uops_retired.l1_hit              4,731,467,983      47.315
mem_load_uops_retired.l2_hit                244,058,833       2.441
mem_load_uops_retired.l3_hit                    769,751       0.008
mem_load_uops_retired.l3_miss                         0       0.000
packet                                      100,000,000       1.000

difference from reference to production:
EVENT                                             TOTAL     /packet
cycles                                    1,409,813,298      14.098
ref_cycles                                1,056,440,016      10.564
instructions                              3,858,706,478      38.587
br_misp_retired.all_branches                    361,693       0.004
mem_load_uops_retired.l1_hit              1,324,505,106      13.245
mem_load_uops_retired.l2_hit                109,539,516       1.095
mem_load_uops_retired.l3_hit                    180,222       0.002
mem_load_uops_retired.l3_miss                         0       0.000
packet                                      100,000,000       1.000
```

Here we see an estimate for the `Tee` app of 14 cycles per packet, 13 L1 cache accesses per packet, and one L2 cache access per packet.

Here is the abbreviated (delta only) output for a `pcap_filter` app:

```
$ sudo taskset -c 0 ./snabb snabbmark appbench apps.packet_filter.pcap_filter PcapFilter '{filter = "not ip6 and not ip and not ether broadcast"}'
...
difference from reference to production:
EVENT                                             TOTAL     /packet
cycles                                    1,701,400,725      17.014
ref_cycles                                1,198,657,392      11.987
instructions                              4,413,841,189      44.138
br_misp_retired.all_branches                    203,686       0.002
mem_load_uops_retired.l1_hit              1,389,742,167      13.897
mem_load_uops_retired.l2_hit                211,134,462       2.111
mem_load_uops_retired.l3_hit                    152,820       0.002
mem_load_uops_retired.l3_miss                         0       0.000
packet                                      100,000,000       1.000
```
The performance here is similar and we can observe one extra L2 cache access. (I wonder what these L2 cache accesses are?)

And for the `keyed_ipv6_tunnel` app:

```
$ sudo taskset -c 0 ./snabb snabbmark appbench apps.keyed_ipv6_tunnel.tunnel SimpleKeyedTunnel '{ local_address = "00::2:1", remote_address = "00::2:1", local_cookie = "12345678", remote_cookie = "12345678", default_gateway_MAC = "a1:b2:c3:d4:e5:f6" }' decapsulated encapsulated
difference from reference to production:
EVENT                                             TOTAL     /packet
cycles                                    4,265,246,460      42.652
ref_cycles                                3,169,706,352      31.697
instructions                             12,000,681,785     120.007
br_misp_retired.all_branches                    675,747       0.007
mem_load_uops_retired.l1_hit              3,773,725,036      37.737
mem_load_uops_retired.l2_hit                230,747,398       2.307
mem_load_uops_retired.l3_hit                    236,410       0.002
mem_load_uops_retired.l3_miss                         0       0.000
packet                                      100,000,000       1.000
```

which is more expensive and has much more L1 cache access (moving packet payload in place).

### Summary

This is really a proof of concept. I see some good things and some bad things.

Good:

1. Start to see per-app behavior that can be useful for optimization.
2. Seems like this method should be fairly robust to measurement error because it avoids any instrumentation overhead.

Bad:

1. `Source->Sink` is limited and unrealistic because no I/O is happening. Many apps will have quite different performance depending on whether packet data is in L1/L2/L3/DRAM and this needs to be understood.
2. Command line syntax is clunky.

I would actually quite like to experiment with having the engine automatically sample performance counters for every app on each call to `pull()` and `push()`. This proof-of-concept will be useful to support that work because results could be compared to estimate measurement error (which I see as the main risk for counting each app callback separately).

This PR is based on musing in #603.