### PR TITLE
engine.report_pmu() [WIP]

### DIFF
--- a/src/lib/pmu.lua
+++ b/src/lib/pmu.lua
@@ -209,7 +209,7 @@ function setup (patterns)
       local EN = bit.lshift(1, 22)
       writemsr(0, 0x186+n, bit.bor(0x10000, USR, EN, code))
    end
-   enabled = {"instructions", "cycles", "ref-cycles"}
+   enabled = {"instructions", "cycles", "ref_cycles"}
    for i = 1, #set do table.insert(enabled, set[i]) end
    return ndropped
 end
@@ -226,11 +226,15 @@ function writemsr (cpu, msr, value)
 end
 
 -- API function (see above)
-function report (set, aux)
+function report (tab, aux)
    aux = aux or {}
-   local names = lib.array_copy(enabled)
-   local values = {}
-   for i = 0, #names-1 do table.insert(values, tonumber(set[i])) end
+   local data = {}
+   for k,v in pairs(tab) do  table.insert(data, {k=k,v=v})  end
+   -- Sort fixed-purpose counters to come first in definite order
+   local fixed = {cycles='0', ref_cycles='1', instructions='2'}
+   table.sort(data, function(x,y)
+                       return (fixed[x.k] or x.k) < (fixed[y.k] or y.k)
+                    end)
    local auxnames, auxvalues = {}, {}
    for k,v in pairs(aux) do 
       table.insert(auxnames,k) 
@@ -244,14 +248,13 @@ function report (set, aux)
    print()
    -- include aux values in results
    for i = 1, #auxnames do
-      table.insert(names, auxnames[i])
-      table.insert(values, auxvalues[i])
+      table.insert(data, {k=auxnames[i], v=auxvalues[i]})
    end
    -- print values
-   for i = 1, #names do
-      io.write(("%-40s %14s"):format(names[i], core.lib.comma_value(values[i])))
+   for i = 1, #data do
+      io.write(("%-40s %14s"):format(data[i].k, core.lib.comma_value(data[i].v)))
       for j = 1, #auxnames do
-         io.write(("%12.3f"):format(tonumber(values[i]/auxvalues[j])))
+         io.write(("%12.3f"):format(tonumber(data[i].v/auxvalues[j])))
       end
       print()
    end
@@ -274,7 +277,7 @@ function profile (f,  events, aux, quiet)
    switch_to(set)
    local res = f()
    switch_to(nil)
-   if not quiet then report(set, aux) end
+   if not quiet then report(to_table(set), aux) end
    return res
 end
 

--- a/src/lib/pmu_x86.dasl
+++ b/src/lib/pmu_x86.dasl
@@ -24,11 +24,15 @@ local dasm = require("dasm")
 
 local gen = {}
 
+-- Table keeping machine code alive to the GC.
+local anchor = {}
+
 -- Utility: assemble code and optionally dump disassembly.
 function assemble (name, prototype, generator)
    local Dst = dasm.new(actions)
    generator(Dst)
    local mcode, size = Dst:build()
+   table.insert(anchor, mcode)
    if debug then
       print("mcode dump: "..name)
       dasm.dump(mcode, size)

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -37,7 +37,7 @@ function basic1 (npackets)
    config.app(c, "Sink", basic_apps.Sink)
    config.link(c, "Source.tx -> Tee.rx")
    config.link(c, "Tee.tx1 -> Sink.rx1")
-   config.link(c, "Tee.tx2 -> Sink.rx2")
+--   config.link(c, "Tee.tx2 -> Sink.rx2")
    engine.configure(c)
    local start = C.get_monotonic_time()
    timer.activate(timer.new("null", function () end, 1e6, 'repeating'))
@@ -48,6 +48,7 @@ function basic1 (npackets)
    local runtime = finish - start
    local packets = link.stats(engine.app_table.Source.output.tx).txpackets
    engine.report()
+   engine.report_pmu()
    print()
    print(("Processed %.1f million packets in %.2f seconds (rate: %.1f Mpps)."):format(packets / 1e6, runtime, packets / runtime / 1e6))
 end


### PR DESCRIPTION
This PR is an alternative to #615 for tracking performance counter values per app.

This branch counts the performance events during each individual `push()` and `pull()` call and accumulates a total for each app. That is to say that it directly counts the number cycles, cache misses, etc, that occur during each callback.

The function `engine.report_pmu()` prints the values for each app and also calculates per-packet values. (The number of packets the apps has processed is determined by its links.)

The event counting seems to work surprisingly well. I was concerned that the individual callbacks would be too short and so there would be too much noise when trying to count their PMU events. However, the initial results are very consistent with the numbers reported in #615 based on long running averages.

Results for a `Tee` app in a `Source->Tee->Sink` network from this branch:

```
$ sudo taskset -c 0 ./snabb snabbmark basic1 1e9
...
*** Tee
EVENT                                             TOTAL     /packet
cycles                                   14,784,901,928      14.780
ref_cycles                               11,104,338,216      11.100
instructions                             36,742,279,315      36.729
br_misp_retired.all_branches                  3,992,662       0.004
mem_load_uops_retired.l1_hit             12,783,402,186      12.779
mem_load_uops_retired.l2_hit                991,799,311       0.991
mem_load_uops_retired.l3_hit                     61,993       0.000
mem_load_uops_retired.l3_miss                         0       0.000
packet                                    1,000,359,900       1.000
```

and from #615 with comparable `/packet` column:

```
difference from reference to production:
EVENT                                             TOTAL     /packet
cycles                                    1,409,813,298      14.098
ref_cycles                                1,056,440,016      10.564
instructions                              3,858,706,478      38.587
br_misp_retired.all_branches                    361,693       0.004
mem_load_uops_retired.l1_hit              1,324,505,106      13.245
mem_load_uops_retired.l2_hit                109,539,516       1.095
mem_load_uops_retired.l3_hit                    180,222       0.002
mem_load_uops_retired.l3_miss                         0       0.000
packet                                      100,000,000       1.000
```

The overhead is significant however and the basic1 benchmark loses around 1/3 of its throughput when sampling the PMU counters. So you would only enable this feature when you are willing to sacrifice overall performance to see per-app performance.

Could be a good plan to tidy up this code and merge it in preference to #615.

I am still interested in having an `appbench` style program that can generate a "datasheet" for an app that estimates how it will perform in different situations (packet size, traffic mix, data in L1/L2/L3/DRAM, etc). However, it should be possible to build that on this code anyway.