### PR TITLE
[LuaJIT] jit.p: Add support for profiling at trace granularity

### DIFF
--- a/lib/luajit/src/jit/p.lua
+++ b/lib/luajit/src/jit/p.lua
@@ -74,7 +74,7 @@ local function prof_cb(th, samples, vmmode)
   -- Collect keys for sample.
   if prof_states then
     if prof_states == "v" then
-      key_state = map_vmmode[vmmode] or vmmode
+      key_state = map_vmmode[vmmode] or "TRACE "..vmmode
     else
       key_state = zone:get() or "(none)"
     end

--- a/lib/luajit/src/lib_jit.c
+++ b/lib/luajit/src/lib_jit.c
@@ -555,7 +555,10 @@ static void jit_profile_callback(lua_State *L2, lua_State *L, int samples,
     setfuncV(L2, L2->top++, funcV(tv));
     setthreadV(L2, L2->top++, L);
     setintV(L2->top++, samples);
-    setstrV(L2, L2->top++, lj_str_new(L2, &vmst, 1));
+    if (vmstate >= 256)
+      setintV(L2->top++, vmstate-256);
+    else
+      setstrV(L2, L2->top++, lj_str_new(L2, &vmst, 1));
     status = lua_pcall(L2, 3, 0, 0);  /* callback(thread, samples, vmstate) */
     if (status) {
       if (G(L2)->panic) G(L2)->panic(L2);

--- a/lib/luajit/src/lj_profile.c
+++ b/lib/luajit/src/lj_profile.c
@@ -155,7 +155,7 @@ static void profile_trigger(ProfileState *ps)
   mask = g->hookmask;
   if (!(mask & (HOOK_PROFILE|HOOK_VMEVENT))) {  /* Set profile hook. */
     int st = g->vmstate;
-    ps->vmstate = st >= 0 ? 'N' :
+    ps->vmstate = st >= 0 ? 256+st :
 		  st == ~LJ_VMST_INTERP ? 'I' :
 		  st == ~LJ_VMST_C ? 'C' :
 		  st == ~LJ_VMST_GC ? 'G' : 'J';


### PR DESCRIPTION
This is a patch written by Mike Pall that makes the profiler "v"
option report the time used by each trace separately. This can be used
to decide which traces to analyze when profiling large programs.

Example:

    $ ./luajit -jp=v ../test.lua
    47%  TRACE 1
    43%  TRACE 2
     6%  Interpreted
     3%  Garbage Collector

Originally posted by Mike on the LuaJIT mailing list:
https://www.freelists.org/post/luajit/Profile-at-trace-granularity,1