### PR TITLE
[LuaJIT] jit.p: Enhance 'v' profiler mode

### DIFF
--- a/lib/luajit/src/jit/dump.lua
+++ b/lib/luajit/src/jit/dump.lua
@@ -75,6 +75,9 @@ local bcline, disass
 -- Active flag, output file handle and dump mode.
 local active, out, dumpmode
 
+-- Information about traces that is remembered for future reference.
+local info = {}
+
 ------------------------------------------------------------------------------
 
 local symtabmt = { __index = false }
@@ -550,6 +553,7 @@ local function dump_trace(what, tr, func, pc, otr, oex)
     if dumpmode.m then dump_mcode(tr) end
   end
   if what == "start" then
+    info[tr] = { func = func, pc = pc, otr = otr, oex = oex }
     if dumpmode.H then out:write('<pre class="ljdump">\n') end
     out:write("---- TRACE ", tr, " ", what)
     if otr then out:write(" ", otr, "/", oex) end
@@ -701,6 +705,7 @@ end
 return {
   on = dumpon,
   off = dumpoff,
-  start = dumpon -- For -j command line option.
+  start = dumpon, -- For -j command line option.
+  info = info
 }
 

--- a/lib/luajit/src/jit/p.lua
+++ b/lib/luajit/src/jit/p.lua
@@ -74,7 +74,7 @@ local function prof_cb(th, samples, vmmode)
   -- Collect keys for sample.
   if prof_states then
     if prof_states == "v" then
-      key_state = map_vmmode[vmmode] or vmmode
+      key_state = map_vmmode[vmmode] or "TRACE "..vmmode
     else
       key_state = zone:get() or "(none)"
     end

--- a/lib/luajit/src/lib_jit.c
+++ b/lib/luajit/src/lib_jit.c
@@ -555,7 +555,10 @@ static void jit_profile_callback(lua_State *L2, lua_State *L, int samples,
     setfuncV(L2, L2->top++, funcV(tv));
     setthreadV(L2, L2->top++, L);
     setintV(L2->top++, samples);
-    setstrV(L2, L2->top++, lj_str_new(L2, &vmst, 1));
+    if (vmstate >= 256)
+      setintV(L2->top++, vmstate-256);
+    else
+      setstrV(L2, L2->top++, lj_str_new(L2, &vmst, 1));
     status = lua_pcall(L2, 3, 0, 0);  /* callback(thread, samples, vmstate) */
     if (status) {
       if (G(L2)->panic) G(L2)->panic(L2);

--- a/lib/luajit/src/lj_profile.c
+++ b/lib/luajit/src/lj_profile.c
@@ -155,7 +155,7 @@ static void profile_trigger(ProfileState *ps)
   mask = g->hookmask;
   if (!(mask & (HOOK_PROFILE|HOOK_VMEVENT))) {  /* Set profile hook. */
     int st = g->vmstate;
-    ps->vmstate = st >= 0 ? 'N' :
+    ps->vmstate = st >= 0 ? 256+st :
 		  st == ~LJ_VMST_INTERP ? 'I' :
 		  st == ~LJ_VMST_C ? 'C' :
 		  st == ~LJ_VMST_GC ? 'G' : 'J';


### PR DESCRIPTION
This change prints more information when profiling at trace granularity. The idea is to make it easier to audit the runtime behavior of your apps: how many traces do they compile into, how are those traces connected together, and which execution path does each trace represent.

This PR builds on #619 and contains the code previously described in issue #611.

More detail with examples:

Previously the 'v' mode would print a terse summary. For example when profiling the rate_limiter app selftest:

```
    $ sudo ./snabb snsh -jdump=+rs,x -jp=v -t apps.rate_limiter.rate_limiter
    47%  TRACE 16
    22%  TRACE 15
    11%  TRACE 14
    10%  TRACE 12
     4%  TRACE 18
     4%  TRACE 24
```

More information is shown with this change:

```
    $ sudo ./snabb snsh -jdump=+rs,x -jp=v -t apps.rate_limiter.rate_limiter
    47%  TRACE  16 (14/4)   ->14       rate_limiter.lua:82
    22%  TRACE  15          ->loop     basic_apps.lua:82
    11%  TRACE  14          ->loop     rate_limiter.lua:73
    10%  TRACE  12          ->loop     basic_apps.lua:26
     4%  TRACE  18 (12/13)  ->14       basic_apps.lua:25
     4%  TRACE  24 (19/10)  ->12       app.lua:293
```

This tells us:

- Is this a side-trace? If so then (PARENT/EXIT) is shown.
- What does the end of the trace link to? (loop, other trace, ..?)
- What source line does the trace begin on? (Requires -jdump to be in use)

Note that it is also possible to combine this profile mode with line based profiling to have more visibility into what is happening inside traces:

```
    45%  TRACE  13 (10/9)   ->10       rate_limiter.lua:82
      -- 33%  counter.lua:add
      -- 32%  packet.lua:free
      -- 20%  freelist.lua:freelist_add
      -- 10%  rate_limiter.lua:method
      --  3%  link.lua:full
    21%  TRACE   8          ->loop     basic_apps.lua:26
      -- 44%  packet.lua:clone
      -- 18%  counter.lua:add
      -- 11%  packet.lua:allocate
      --  9%  freelist.lua:allocate
      --  9%  basic_apps.lua:method
      --  7%  link.lua:full
      --  4%  link.lua:transmit
    19%  TRACE  10          ->loop     rate_limiter.lua:73
      -- 58%  rate_limiter.lua:method
      -- 21%  link.lua:receive
      -- 17%  counter.lua:add
     7%  TRACE  11          ->loop     basic_apps.lua:82
      -- 74%  counter.lua:add
      -- 21%  link.lua:receive
      --  5%  packet.lua:free_internal
```