### PR TITLE
virtio/net_device: don't initialize 'avail' from 'used'

### DIFF
--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -417,9 +417,9 @@ end
 function VirtioNetDevice:set_vring_addr(idx, ring)
 
    self.virtq[idx].virtq = ring
-   self.virtq[idx].avail = tonumber(ring.used.idx)
+   self.virtq[idx].avail = tonumber(ring.avail.idx)
    self.virtq[idx].used = tonumber(ring.used.idx)
-   print(string.format("rxavail = %d rxused = %d", self.virtq[idx].avail, self.virtq[idx].used))
+   debug(string.format("rxavail = %d rxused = %d", self.virtq[idx].avail, self.virtq[idx].used))
    ring.used.flags = C.VRING_F_NO_NOTIFY
 end
 


### PR DESCRIPTION
*This is a subtle change that requires more thought and testing.*

The issue is: at what position do we start processing elements from
the virtio 'avail' ring? This change starts from the initial value
declared by the virtual machine (avail->idx). That essentially means
that we assume that the ring is initially empty.

The previous behavior is to start reading the 'avail' ring from the
position of 'used->idx'. The intention here is to allow for some valid
elements to already exist on the avail ring. We assume that the
'avail' and 'used' rings have their indexes synchronized (start from
the same index) and that the avail ring elements between
used->idx..avail->idx are the elements that we have not processed yet.

Why this question at all?

Well - our Virtio-net/vhost-user implementation attempts to allow the
snabb process to restart and reattach itself to a running virtual
machine. This is not a standard feature of Virtio-net but rather extra
that we want to support. The issue is that when we reattach to a
virtual machine we want to decide which of its buffers we have already
processed and which we have not. This is important so that the VM's
receive buffers don't leak/disappear when the snabb process restarts.

The old behavior before this patch has been working will in this way.

However, now we are interoperability testing with a new VM and this
seems to be causing an error. Specifically the issue seems to be that
the guest's 'avail' and 'used' rings do _not_ start with the same
index. This means that it is too simplistic to use the used->idx field
to decide where to start processing the avail ring. And so this patch
is intended to potentially improve compatability at the expense of
breaking the restart-and-reconnect functionality.

Any thoughts @nnikolaev-virtualopensystems @javierguerragiraldez?