### PR TITLE
intel10g: Enable TX prefetch for 14.8 Mpps

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -135,6 +135,7 @@ function M_sf:init ()
          :init_statistics()
          :init_receive()
          :init_transmit()
+         :init_txdesc_prefetch()
          :wait_enable()
          :wait_linkup()
 
@@ -420,8 +421,12 @@ end
 function M_sf:init_transmit ()
    self.r.HLREG0:set(bits{TXCRCEN=0})
    self:set_transmit_descriptors()
-   self.r.TXDCTL:set(bits{Enable=25, SWFLSH=26, hthresh=8} + 32)
    self.r.DMATXCTL:set(bits{TE=0})
+   return self
+end
+
+function M_sf:init_txdesc_prefetch ()
+   self.r.TXDCTL:set(bits{SWFLSH=26, hthresh=8} + 32)
    return self
 end
 

--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -420,6 +420,7 @@ end
 function M_sf:init_transmit ()
    self.r.HLREG0:set(bits{TXCRCEN=0})
    self:set_transmit_descriptors()
+   self.r.TXDCTL:set(bits{Enable=25, SWFLSH=26, hthresh=8} + 32)
    self.r.DMATXCTL:set(bits{TE=0})
    return self
 end
@@ -938,7 +939,7 @@ end
 
 function M_vf:enable_transmit()
    self.pf.r.DMATXCTL:set(bits{TE=0})
-   self.r.TXDCTL:set(bits{Enable=25, SWFLSH=26})
+   self.r.TXDCTL:set(bits({Enable=25, SWFLSH=26, hthresh=8}) + 32)
    self.r.TXDCTL:wait(bits{Enable=25})
    return self
 end
@@ -952,7 +953,7 @@ function M_vf:disable_transmit(reenable)
    self.pf.r.PFVFTE[math.floor(self.poolnum/32)]:clr(bits{VFTE=self.poolnum%32})
 
    if reenable then
-      self.r.TXDCTL:set(bits{Enable=25, SWFLSH=26})
+      self.r.TXDCTL:set(bits({Enable=25, SWFLSH=26, hthresh=8}) + 32)
    --    self.r.TXDCTL:wait(bits{Enable=25})
    end
    return self


### PR DESCRIPTION
Enable the "TX descriptor prefetching" feature. This is required for the 82599 NIC to achieve line-rate transmission with 64-byte packets.

Resolves SnabbCo/snabbswitch#622.