### PR TITLE
snsh: Added '-q' to break program to REPL via keyboard

### DIFF
--- a/src/program/snsh/README
+++ b/src/program/snsh/README
@@ -21,4 +21,6 @@ Execute SCRIPT if specified and then exit.
                                http://luajit.org/running.html
   -P PATH,   --package-path PATH
                              Use PATH as the Lua 'package.path'.
+  -q,        --sigquit-repl  Enter the REPL on SIGQUIT (Control-\).
+                             (Hook is only effective during engine.main().)
   -h,        --help          Print this usage message.

--- a/src/program/snsh/README
+++ b/src/program/snsh/README
@@ -21,6 +21,6 @@ Execute SCRIPT if specified and then exit.
                                http://luajit.org/running.html
   -P PATH,   --package-path PATH
                              Use PATH as the Lua 'package.path'.
-  -q,        --sigquit-repl  Enter the REPL on SIGQUIT (Control-\).
+  -q=repl,   --sigquit=repl  Enter the REPL on SIGQUIT (Control-\).
                              (Hook is only effective during engine.main().)
   -h,        --help          Print this usage message.

--- a/src/program/snsh/snsh.lua
+++ b/src/program/snsh/snsh.lua
@@ -12,7 +12,7 @@ local long_opts = {
    interactive = "i",
    debug = "d",
    jit = "j",
-   ["sigquit-repl"] = "q",
+   sigquit = "q",
    help = "h",
 }
 
@@ -26,7 +26,7 @@ function run (parameters)
    function opt.h (arg) print(usage) main.exit(0)            end
    function opt.l (arg) require(arg)            noop = false end
    function opt.t (arg) require(arg).selftest() noop = false end
-   function opt.q (arg) hook_repl_on_sigquit()               end
+   function opt.q (arg) hook_sigquit(arg)                    end
    function opt.d (arg) _G.developer_debug = true            end
    function opt.p (arg) program = arg                        end
    function opt.i (arg) start_repl = true       noop = false end
@@ -56,7 +56,7 @@ function run (parameters)
    end
 
    -- Execute command line arguments
-   parameters = lib.dogetopt(parameters, opt, "hl:p:t:die:j:P:q", long_opts)
+   parameters = lib.dogetopt(parameters, opt, "hl:p:t:die:j:P:q:", long_opts)
 
    if program then
       local mod = (("program.%s.%s"):format(program, program))
@@ -112,7 +112,11 @@ end
 
 -- Cause SIGQUIT to enter the REPL.
 -- SIGQUIT can be triggered interactively with `Control \' in a terminal.
-function hook_repl_on_sigquit ()
+function hook_sigquit (action)
+   if action ~= 'repl' then
+      print("ignoring unrecognized SIGQUIT action: " .. action)
+      os.exit(1)
+   end
    local S = require("syscall")
    local fd = S.signalfd("quit", "nonblock") -- handle SIGQUIT via fd
    S.sigprocmask("block", "quit")            -- block traditional handler

--- a/src/program/snsh/snsh.lua
+++ b/src/program/snsh/snsh.lua
@@ -12,6 +12,7 @@ local long_opts = {
    interactive = "i",
    debug = "d",
    jit = "j",
+   ["sigquit-repl"] = "q",
    help = "h",
 }
 
@@ -25,6 +26,7 @@ function run (parameters)
    function opt.h (arg) print(usage) main.exit(0)            end
    function opt.l (arg) require(arg)            noop = false end
    function opt.t (arg) require(arg).selftest() noop = false end
+   function opt.q (arg) hook_repl_on_sigquit()               end
    function opt.d (arg) _G.developer_debug = true            end
    function opt.p (arg) program = arg                        end
    function opt.i (arg) start_repl = true       noop = false end
@@ -54,7 +56,7 @@ function run (parameters)
    end
 
    -- Execute command line arguments
-   parameters = lib.dogetopt(parameters, opt, "hl:p:t:die:j:P:", long_opts)
+   parameters = lib.dogetopt(parameters, opt, "hl:p:t:die:j:P:q", long_opts)
 
    if program then
       local mod = (("program.%s.%s"):format(program, program))
@@ -106,6 +108,24 @@ function repl ()
          io.stdout:flush()
       end
    until not line
+end
+
+-- Cause SIGQUIT to enter the REPL.
+-- SIGQUIT can be triggered interactively with `Control \' in a terminal.
+function hook_repl_on_sigquit ()
+   local S = require("syscall")
+   local fd = S.signalfd("quit", "nonblock") -- handle SIGQUIT via fd
+   S.sigprocmask("block", "quit")            -- block traditional handler
+   local timer = require("core.timer")
+   timer.activate(timer.new("sigquit-repl",
+                            function ()
+                               if (#S.util.signalfd_read(fd) > 0) then
+                                  print("[snsh: SIGQUIT caught - entering REPL]")
+                                  repl()
+                               end
+                            end,
+                            1e4,
+                            'repeating'))
 end
 
 


### PR DESCRIPTION
Now you can run any Snabb-based program in a mode that supports
interrupting it with the keyboard (Control-\ i.e. SIGQUIT) such that
it leaves the breathe loop and enters an interactive read-eval-print
loop (REPL). Here you can poke around with arbitrary Lua expressions
and finally return back to the engine by pressing Control-d (EOF).

The `snsh` argument -q (--sigquit-repl) enables a timer callback in the
engine that checks if SIGQUIT has been received and starts a
REPL. This can be combined with the -p (--program) argument to run
another program such as packetblaster or snabbnfv.

For example:

  snabb snsh -q -p packetblaster replay 64.cap 0000:01:00.0

will run packetblaster but with the hook enabled such that each time
you press Control-\ the process will receive a SIGQUIT and enter the
REPL like this:

    0000:01:00.1    TXDGPC (TX packets)     13,154,784      GOTCL (TX octets)       894,522,388
    ^\[snsh: SIGQUIT caught - entering REPL]
    Snabb>

Note: SIGQUIT is detected by a hook function running on a timer and so
it is only effective when the engine's breathe loop is running. (The
REPL does not run inside a Unix signal handler -- the signal only sets
a flag saying that it should be started.)