### PR TITLE
src/README.md: Document engine.configure() reconfiguration

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -172,8 +172,15 @@ variable.
 
 — Function **engine.configure** *config*
 
-Configure the engine to use a new config *config*.
+Configure the engine to use a new config *config*. You can safely call
+this method many times to incrementally update the running app
+network. The engine updates the app network as follows:
 
+ * Apps that did not exist in the old configuration are started.
+ * Apps that do not exist in the new configuration are stopped. (The app `stop()` method is called if defined.)
+ * Apps with unchanged configurations are preserved.
+ * Apps with changed configurations are updated by calling their `reconfig()` method. If the `reconfig()` method is not implemented then the old instance is stopped a new one started.
+ * Links with unchanged endpoints are preserved.
 
 — Function **engine.main** *options*
 

--- a/src/README.md.src
+++ b/src/README.md.src
@@ -198,8 +198,15 @@ variable.
 
 — Function **engine.configure** *config*
 
-Configure the engine to use a new config *config*.
+Configure the engine to use a new config *config*. You can safely call
+this method many times to incrementally update the running app
+network. The engine updates the app network as follows:
 
+ * Apps that did not exist in the old configuration are started.
+ * Apps that do not exist in the new configuration are stopped. (The app `stop()` method is called if defined.)
+ * Apps with unchanged configurations are preserved.
+ * Apps with changed configurations are updated by calling their `reconfig()` method. If the `reconfig()` method is not implemented then the old instance is stopped a new one started.
+ * Links with unchanged endpoints are preserved.
 
 — Function **engine.main** *options*
 


### PR DESCRIPTION
Explain the algorithm for updating the app network when `engine.configure()` is called multiple times.