### PR TITLE
lib.lua tweaks

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -271,6 +271,7 @@ function M_sf:init_snmp ()
          r[k].v[0] = r[k].r()
       end
    end
+   self.logger = lib.logger_new({ module = 'intel10g' })
    local t = timer.new("Interface "..self.pciaddress.." status checker",
                        function(t)
                           local old = ifTable:get('ifOperStatus')
@@ -279,9 +280,9 @@ function M_sf:init_snmp ()
                              new = 2
                           end
                           if old ~= new then
-                             print("Interface "..self.pciaddress..
-                                   " status change: "..status[old]..
-                                   " => "..status[new])
+                             self.logger:log("Interface "..self.pciaddress..
+                                             " status change: "..status[old]..
+                                             " => "..status[new])
                              ifTable:set('ifOperStatus', new)
                              ifTable:set('ifLastChange', 0)
                              ifTable:set('_X_ifLastChange_TicksBase',

--- a/src/apps/ipv6/nd_light.lua
+++ b/src/apps/ipv6/nd_light.lua
@@ -318,3 +318,26 @@ function nd_light:stop ()
    packet.free(self._next_hop.packet)
    packet.free(self._sna.packet)
 end
+
+function selftest ()
+   local sink = require("apps.basic.basic_apps").Sink
+   local c = config.new()
+   config.app(c, "nd1", nd_light, { local_mac = "00:00:00:00:00:01",
+                                    local_ip  = "2001:DB8::1",
+                                    next_hop  = "2001:DB8::2" })
+   config.app(c, "nd2", nd_light, { local_mac = "00:00:00:00:00:02",
+                                    local_ip  = "2001:DB8::2",
+                                    next_hop  = "2001:DB8::1" })
+   config.app(c, "sink1", sink)
+   config.app(c, "sink2", sink)
+   config.link(c, "nd1.south -> nd2.south")
+   config.link(c, "nd2.south -> nd1.south")
+   config.link(c, "sink1.tx -> nd1.north")
+   config.link(c, "nd1.north -> sink1.rx")
+   config.link(c, "sink2.tx -> nd2.north")
+   config.link(c, "nd2.north -> sink2.rx")
+   engine.configure(c)
+   engine.main({ duration = 2 })
+   assert(engine.app_table.nd1._eth_header)
+   assert(engine.app_table.nd2._eth_header)
+end

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -473,14 +473,16 @@ function token_bucket_new (config)
    return tb
 end
 
--- The rate can be set with the rate() method at any time, which
--- empties the token bucket an also returns the previous value.  If
--- called with a nil argument, returns the currently configured rate.
+-- The rate can be set with the rate() method at any time, which fills
+-- the token bucket an also returns the previous value.  If called
+-- with a nil argument, returns the currently configured rate.
 function token_bucket:rate (rate)
    if rate ~= nil then
+      local old_rate = self._rate
       self._rate = rate
       self._max_tokens = math.max(rate, 1)
       self._tokens = self._max_tokens
+      return old_rate
    end
    return self._rate
 end

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -480,7 +480,7 @@ function token_bucket:rate (rate)
    if rate ~= nil then
       self._rate = rate
       self._max_tokens = math.max(rate, 1)
-      self._tokens = 0
+      self._tokens = self._max_tokens
    end
    return self._rate
 end

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -5,6 +5,7 @@ local C = ffi.C
 local getopt = require("lib.lua.alt_getopt")
 local syscall = require("syscall")
 require("core.clib_h")
+local bit = require("bit")
 local band, bor, bnot, lshift, rshift, bswap =
    bit.band, bit.bor, bit.bnot, bit.lshift, bit.rshift, bit.bswap
 
@@ -358,22 +359,6 @@ else
 end
 ntohl = htonl
 ntohs = htons
-
--- The fact that BitOps return signed integers is irritating, to say
--- the least.  One counter-intuitive consequence is that, for example,
---
---   bit.bswap(bit.bswap(0x80000000)) == 0x80000000
---
--- is false, because the lhs is a negative number.  To compare a
--- 32-bit quantity with the result of ntohl() or htonl(), one needs to
--- use the equivalent of
---
---   bit.band(number, 0xFFFFFFFF) == ntohl(other_number)
---
--- The followig utility can be used for that purpose.
-function eq32 (a, b)
-   return band(a, 0xFFFFFFFF) == band(b, 0xFFFFFFFF)
-end
 
 -- Manipulation of bit fields in uint{8,16,32)_t stored in network
 -- byte order.  Using bit fields in C structs is compiler-dependent

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -569,7 +569,7 @@ logger_default = {
    flush = true,
    module = '',
    date = true,
-   date_fmt = "%b %Y %H:%M:%S ",
+   date_fmt = "%b %d %Y %H:%M:%S ",
 }
 logger_throttle = {
    interval = 10, -- Sampling interval for discard rate

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -560,9 +560,9 @@ end
 -- is increased by 1/4 of the original rate, i.e. it takes at least 40
 -- seconds to ramp back up to the original rate.
 --
-local logger = {}
--- Default configuration
-logger.default = {
+-- The tables lib.logger_default and lib.logger_throttle are exposed
+-- to the user as part of the API.
+logger_default = {
    rate = 10,
    discard_rate = 0.5,
    fh = io.stdout,
@@ -571,12 +571,15 @@ logger.default = {
    date = true,
    date_fmt = "%b %Y %H:%M:%S ",
 }
--- Auto-throttle configuration
-logger.throttle = {
+logger_throttle = {
    interval = 10, -- Sampling interval for discard rate
    excess = 5,   -- Multiple of rate at which to start throttling
    increment = 4, -- Fraction of rate to increase for un-throttling
    min_rate = 0.1, -- Minimum throttled rate
+}
+local logger = {
+   default = logger_default,
+   throttle = logger_throttle,
 }
 logger.mt = { __index = logger }
 

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -599,7 +599,7 @@ function logger:log (msg)
       local throttle  = self._throttle
       local date = ''
       if config.date then
-	 date = os.date(config.date_fmt)
+         date = os.date(config.date_fmt)
       end
       local preamble = date..self._preamble
       local fh = config.fh
@@ -609,35 +609,35 @@ function logger:log (msg)
       local drate = throttle.discards/interval
       local current_rate = self._tb:rate()
       if samples >= 1 then
-	 if throttle.discards > 0 then
-	    fh:write(string.format(preamble.."%d messages discarded in %d seconds\n",
-				   throttle.discards, now-throttle.tstamp))
-	 end
-	 if drate > throttle.rate then
-	    local min_rate = throttle.min_rate
-	    if current_rate > min_rate then
-	       local throttle_rate = math.max(min_rate,
-					      current_rate/2^samples)
-	       fh:write(string.format(preamble.."throttling logging rate to "
-				      .."%.2f Hz%s\n",
-				   throttle_rate,
-				   (throttle_rate == min_rate and ' (minimum)') or ''))
-	       self._tb:rate(throttle_rate)
-	    end
-	 else
-	    local configured_rate = config.rate
-	    if current_rate < configured_rate then
-	       local throttle_rate = math.min(configured_rate,
-					      current_rate + throttle.increment*samples)
-	       fh:write(string.format(preamble.."unthrottling logging rate to "
-				      .."%.2f Hz%s\n",
-				   throttle_rate,
-				   (throttle_rate == configured_rate and ' (maximum)') or ''))
-	       self._tb:rate(throttle_rate)
-	    end
-	 end
-	 throttle.discards = 0
-	 throttle.tstamp = now
+         if throttle.discards > 0 then
+            fh:write(string.format(preamble.."%d messages discarded in %d seconds\n",
+                                   throttle.discards, now-throttle.tstamp))
+         end
+         if drate > throttle.rate then
+            local min_rate = throttle.min_rate
+            if current_rate > min_rate then
+               local throttle_rate = math.max(min_rate,
+                                              current_rate/2^samples)
+               fh:write(string.format(preamble.."throttling logging rate to "
+                                      .."%.2f Hz%s\n",
+                                   throttle_rate,
+                                   (throttle_rate == min_rate and ' (minimum)') or ''))
+               self._tb:rate(throttle_rate)
+            end
+         else
+            local configured_rate = config.rate
+            if current_rate < configured_rate then
+               local throttle_rate = math.min(configured_rate,
+                                              current_rate + throttle.increment*samples)
+               fh:write(string.format(preamble.."unthrottling logging rate to "
+                                      .."%.2f Hz%s\n",
+                                   throttle_rate,
+                                   (throttle_rate == configured_rate and ' (maximum)') or ''))
+               self._tb:rate(throttle_rate)
+            end
+         end
+         throttle.discards = 0
+         throttle.tstamp = now
       end
       fh:write(preamble..msg..'\n')
       if config.flush then fh:flush() end

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -5,6 +5,8 @@ local C = ffi.C
 local getopt = require("lib.lua.alt_getopt")
 local syscall = require("syscall")
 require("core.clib_h")
+local band, bor, bnot, lshift, rshift, bswap =
+   bit.band, bit.bor, bit.bnot, bit.lshift, bit.rshift, bit.bswap
 
 -- Returns true if x and y are structurally similar (isomorphic).
 function equal (x, y)
@@ -159,14 +161,14 @@ end
 function bits (bitset, basevalue)
    local sum = basevalue or 0
    for _,n in pairs(bitset) do
-      sum = bit.bor(sum, bit.lshift(1, n))
+      sum = bor(sum, lshift(1, n))
    end
    return sum
 end
 
 -- Return true if bit number 'n' of 'value' is set.
 function bitset (value, n)
-   return bit.band(value, bit.lshift(1, n)) ~= 0
+   return band(value, lshift(1, n)) ~= 0
 end
 
 -- Manipulation of bit fields in uint{8,16,32)_t stored in network
@@ -190,17 +192,17 @@ function bitfield(size, struct, member, offset, nbits, value)
       field = struct[member]
    end
    local shift = size-(nbits+offset)
-   local mask = bit.lshift(2^nbits-1, shift)
-   local imask = bit.bnot(mask)
+   local mask = lshift(2^nbits-1, shift)
+   local imask = bnot(mask)
    if value then
-      field = bit.bor(bit.band(field, imask), bit.lshift(value, shift))
+      field = bor(band(field, imask), lshift(value, shift))
       if conv then
          struct[member] = conv.hton(field)
       else
          struct[member] = field
       end
    else
-      return bit.rshift(bit.band(field, mask), shift)
+      return rshift(band(field, mask), shift)
    end
 end
 
@@ -326,17 +328,17 @@ function update_csum (ptr, len,  csum0)
    ptr = ffi.cast("uint8_t*", ptr)
    local sum = csum0 or 0LL
    for i = 0, len-2, 2 do
-      sum = sum + bit.lshift(ptr[i], 8) + ptr[i+1]
+      sum = sum + lshift(ptr[i], 8) + ptr[i+1]
    end
-   if len % 2 == 1 then sum = sum + bit.lshift(ptr[len-1], 1) end
+   if len % 2 == 1 then sum = sum + lshift(ptr[len-1], 1) end
    return sum
 end
 
 function finish_csum (sum)
-   while bit.band(sum, 0xffff) ~= sum do
-      sum = bit.band(sum + bit.rshift(sum, 16), 0xffff)
+   while band(sum, 0xffff) ~= sum do
+      sum = band(sum + rshift(sum, 16), 0xffff)
    end
-   return bit.band(bit.bnot(sum), 0xffff)
+   return band(bnot(sum), 0xffff)
 end
 
 
@@ -386,11 +388,27 @@ if ffi.abi("be") then
    function htonl(b) return b end
    function htons(b) return b end
 else
-   function htonl(b) return bit.bswap(b) end
-   function htons(b) return bit.rshift(bit.bswap(b), 16) end
+   function htonl(b) return bswap(b) end
+   function htons(b) return rshift(bswap(b), 16) end
 end
 ntohl = htonl
 ntohs = htons
+
+-- The fact that BitOps return signed integers is irritating, to say
+-- the least.  One counter-intuitive consequence is that, for example,
+--
+--   bit.bswap(bit.bswap(0x80000000)) == 0x80000000
+--
+-- is false, because the lhs is a negative number.  To compare a
+-- 32-bit quantity with the result of ntohl() or htonl(), one needs to
+-- use the equivalent of
+--
+--   bit.band(number, 0xFFFFFFFF) == ntohl(other_number)
+--
+-- The followig utility can be used for that purpose.
+function eq32 (a, b)
+   return band(a, 0xFFFFFFFF) == band(b, 0xFFFFFFFF)
+end
 
 -- Process ARGS using ACTIONS with getopt OPTS/LONG_OPTS.
 -- Return the remaining unprocessed arguments.

--- a/src/lib/protocol/ethernet.lua
+++ b/src/lib/protocol/ethernet.lua
@@ -1,9 +1,11 @@
 module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C
+local lib = require("core.lib")
 local header = require("lib.protocol.header")
 local ipv6 = require("lib.protocol.ipv6")
 local band = require("bit").band
+local ntohs, htons = lib.ntohs, lib.htons
 
 local ether_header_t = ffi.typeof[[
 struct {
@@ -116,9 +118,9 @@ end
 function ethernet:type (t)
    local h = self:header()
    if t ~= nil then
-      h.ether_type = C.htons(t)
+      h.ether_type = htons(t)
    else
-      return(C.ntohs(h.ether_type))
+      return(ntohs(h.ether_type))
    end
 end
 

--- a/src/lib/protocol/gre.lua
+++ b/src/lib/protocol/gre.lua
@@ -5,6 +5,8 @@ local header = require("lib.protocol.header")
 local lib = require("core.lib")
 local bitfield = lib.bitfield
 local ipsum = require("lib.checksum").ipsum
+local ntohs, htons, ntohl, htonl =
+   lib.ntohs, lib.htons, lib.ntohl, lib.htonl
 
 -- GRE uses a variable-length header as specified by RFCs 2784 and
 -- 2890.  The actual size is determined by flag bits in the base
@@ -123,16 +125,16 @@ function gre:checksum (payload, length)
    end
    if payload ~= nil then
       -- Calculate and set the checksum
-      self:header().csum = C.htons(checksum(self:header(), payload, length))
+      self:header().csum = htons(checksum(self:header(), payload, length))
    end
-   return C.ntohs(self:header().csum)
+   return ntohs(self:header().csum)
 end
 
 function gre:checksum_check (payload, length)
    if not self._checksum then
       return true
    end
-   return checksum(self:header(), payload, length) == C.ntohs(self:header().csum)
+   return checksum(self:header(), payload, length) == lib.ntohs(self:header().csum)
 end
 
 -- Returns nil if keying is disabled. Otherwise, the key is set to the
@@ -143,17 +145,17 @@ function gre:key (key)
       return nil
    end
    if key ~= nil then
-      self:header().key = C.htonl(key)
+      self:header().key = htonl(key)
    else
-      return C.ntohl(self:header().key)
+      return ntohl(self:header().key)
    end
 end
 
 function gre:protocol (protocol)
    if protocol ~= nil then
-      self:header().protocol = C.htons(protocol)
+      self:header().protocol = htons(protocol)
    end
-   return(C.ntohs(self:header().protocol))
+   return(ntohs(self:header().protocol))
 end
 
 return gre

--- a/src/lib/protocol/icmp/header.lua
+++ b/src/lib/protocol/icmp/header.lua
@@ -74,11 +74,11 @@ end
 
 function icmp:checksum (payload, length, ipv6)
    local header = self:header()
-   header.checksum = C.htons(checksum(header, payload, length, ipv6))
+   header.checksum = lib.htons(checksum(header, payload, length, ipv6))
 end
 
 function icmp:checksum_check (payload, length, ipv6)
-   return checksum(self:header(), payload, length, ipv6) == C.ntohs(self:header().checksum)
+   return checksum(self:header(), payload, length, ipv6) == lib.ntohs(self:header().checksum)
 end
 
 return icmp

--- a/src/lib/protocol/ipv4.lua
+++ b/src/lib/protocol/ipv4.lua
@@ -4,6 +4,8 @@ local C = ffi.C
 local lib = require("core.lib")
 local header = require("lib.protocol.header")
 local ipsum = require("lib.checksum").ipsum
+local htons, ntohs, htonl, ntohl =
+   lib.htons, lib.ntohs, lib.htonl, lib.ntohl
 
 -- TODO: generalize
 local AF_INET = 2
@@ -54,7 +56,7 @@ ipv4._ulp = {
 
 function ipv4:new (config)
    local o = ipv4:superClass().new(self)
-   o:header().ihl_v_tos = C.htons(0x4000) -- v4
+   o:header().ihl_v_tos = htons(0x4000) -- v4
    o:ihl(o:sizeof() / 4)
    o:dscp(config.dscp or 0)
    o:ecn(config.ecn or 0)
@@ -105,17 +107,17 @@ end
 
 function ipv4:total_length (length)
    if length ~= nil then
-      self:header().total_length = C.htons(length)
+      self:header().total_length = htons(length)
    else
-      return(C.ntohs(self:header().total_length))
+      return(ntohs(self:header().total_length))
    end
 end
 
 function ipv4:id (id)
    if id ~= nil then
-      self:header().id = C.htons(id)
+      self:header().id = htons(id)
    else
-      return(C.ntohs(self:header().id))
+      return(ntohs(self:header().id))
    end
 end
 
@@ -144,9 +146,9 @@ function ipv4:protocol (protocol)
 end
 
 function ipv4:checksum ()
-   self:header().checksum = C.htons(ipsum(ffi.cast("uint8_t *", self:header()),
-                                          self:sizeof(), 0))
-   return C.ntohs(self:header().checksum)
+   self:header().checksum = htons(ipsum(ffi.cast("uint8_t *", self:header()),
+                                        self:sizeof(), 0))
+   return ntohs(self:header().checksum)
 end
 
 function ipv4:src (ip)
@@ -191,7 +193,7 @@ function ipv4:pseudo_header (ulplen, proto)
    local ph = ipv4hdr_pseudo_t()
    local h = self:header()
    ffi.copy(ph, h.src_ip, 2*ipv4_addr_t_size)  -- Copy source and destination
-   ph.ulp_length = C.htons(ulplen)
+   ph.ulp_length = htons(ulplen)
    ph.ulp_protocol = proto
    return(ph)
 end

--- a/src/lib/protocol/ipv6.lua
+++ b/src/lib/protocol/ipv6.lua
@@ -3,6 +3,7 @@ local ffi = require("ffi")
 local C = ffi.C
 local lib = require("core.lib")
 local header = require("lib.protocol.header")
+local htons, ntohs = lib.htons, lib.ntohs
 
 local AF_INET6 = 10
 local INET6_ADDRSTRLEN = 48
@@ -126,9 +127,9 @@ end
 
 function ipv6:payload_length (length)
    if length ~= nil then
-      self:header().payload_length = C.htons(length)
+      self:header().payload_length = htons(length)
    else
-      return(C.ntohs(self:header().payload_length))
+      return(ntohs(self:header().payload_length))
    end
 end
 
@@ -182,7 +183,7 @@ function ipv6:pseudo_header (plen, nh)
    ffi.fill(ph, ffi.sizeof(ph))
    local h = self:header()
    ffi.copy(ph, h.src_ip, 32)  -- Copy source and destination
-   ph.ulp_length = C.htons(plen)
+   ph.ulp_length = htons(plen)
    ph.next_header = nh
    return(ph)
 end

--- a/src/lib/protocol/keyed_ipv6_tunnel.lua
+++ b/src/lib/protocol/keyed_ipv6_tunnel.lua
@@ -16,6 +16,8 @@ module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C
 local header = require("lib.protocol.header")
+local lib = require("core.lib")
+local htonl, ntohl = lib.htonl, lib.ntohl
 
 ffi.cdef[[
       typedef union {
@@ -90,9 +92,9 @@ function tunnel:session_id (id)
    local h = self:header()
    if id ~= nil then
       assert(id ~= 0, "invalid session id 0")
-      h.session_id = C.htonl(id)
+      h.session_id = htonl(id)
    else
-      return C.ntohl(h.session_id)
+      return ntohl(h.session_id)
    end
 end
 

--- a/src/lib/protocol/tcp.lua
+++ b/src/lib/protocol/tcp.lua
@@ -4,6 +4,8 @@ local C = ffi.C
 local lib = require("core.lib")
 local header = require("lib.protocol.header")
 local ipsum = require("lib.checksum").ipsum
+local ntohs, htons, ntohl, htonl =
+   lib.ntohs, lib.htons, lib.ntohl, lib.htonl
 
 local tcp_header_t = ffi.typeof[[
 struct {
@@ -55,33 +57,33 @@ end
 function tcp:src_port (port)
    local h = self:header()
    if port ~= nil then
-      h.src_port = C.htons(port)
+      h.src_port = htons(port)
    end
-   return C.ntohs(h.src_port)
+   return ntohs(h.src_port)
 end
 
 function tcp:dst_port (port)
    local h = self:header()
    if port ~= nil then
-      h.dst_port = C.htons(port)
+      h.dst_port = htons(port)
    end
-   return C.ntohs(h.dst_port)
+   return ntohs(h.dst_port)
 end
 
 function tcp:seq_num (seq)
    local h = self:header()
    if seq ~= nil then
-      h.seq = C.htonl(seq)
+      h.seq = htonl(seq)
    end
-   return C.ntohl(h.seq)
+   return ntohl(h.seq)
 end
 
 function tcp:ack_num (ack)
    local h = self:header()
    if ack ~= nil then
-      h.ack = C.htonl(ack)
+      h.ack = htonl(ack)
    end
-   return C.ntohl(h.ack)
+   return ntohl(h.ack)
 end
 
 function tcp:offset (offset)
@@ -135,9 +137,9 @@ end
 function tcp:window_size (window_size)
    local h = self:header()
    if window_size ~= nil then
-      h.window_size = C.htons(window_size)
+      h.window_size = htons(window_size)
    end
-   return C.ntohs(h.window_size)
+   return ntohs(h.window_size)
 end
 
 function tcp:checksum (payload, length, ip)
@@ -154,9 +156,9 @@ function tcp:checksum (payload, length, ip)
       csum = ipsum(ffi.cast("uint8_t *", h),
                    self:sizeof(), bit.bnot(csum))
       -- Add TCP payload
-      h.checksum = C.htons(ipsum(payload, length, bit.bnot(csum)))
+      h.checksum = htons(ipsum(payload, length, bit.bnot(csum)))
    end
-   return C.ntohs(h.checksum)
+   return ntohs(h.checksum)
 end
 
 -- override the default equality method

--- a/src/lib/protocol/udp.lua
+++ b/src/lib/protocol/udp.lua
@@ -3,6 +3,8 @@ local ffi = require("ffi")
 local C = ffi.C
 local header = require("lib.protocol.header")
 local ipsum = require("lib.checksum").ipsum
+local lib = require("core.lib")
+local htons, ntohs = lib.htons, lib.ntohs
 
 local udp_header_t = ffi.typeof[[
 struct {
@@ -37,25 +39,25 @@ end
 function udp:src_port (port)
    local h = self:header()
    if port ~= nil then
-      h.src_port = C.htons(port)
+      h.src_port = htons(port)
    end
-   return C.ntohs(h.src_port)
+   return ntohs(h.src_port)
 end
 
 function udp:dst_port (port)
    local h = self:header()
    if port ~= nil then
-      h.dst_port = C.htons(port)
+      h.dst_port = htons(port)
    end
-   return C.ntohs(h.dst_port)
+   return ntohs(h.dst_port)
 end
 
 function udp:length (len)
    local h = self:header()
    if len ~= nil then
-      h.len = C.htons(len)
+      h.len = htons(len)
    end
-   return C.ntohs(h.len)
+   return ntohs(h.len)
 end
 
 function udp:checksum (payload, length, ip)
@@ -72,9 +74,9 @@ function udp:checksum (payload, length, ip)
       csum = ipsum(ffi.cast("uint8_t *", h),
                    self:sizeof(), bit.bnot(csum))
       -- Add UDP payload
-      h.checksum = C.htons(ipsum(payload, length, bit.bnot(csum)))
+      h.checksum = htons(ipsum(payload, length, bit.bnot(csum)))
    end
-   return C.ntohs(h.checksum)
+   return ntohs(h.checksum)
 end
 
 -- override the default equality method


### PR DESCRIPTION
This changeset covers three issues

* Caching of `bit` in `lib.lua`
* Use of native Lua endian conversion
* Logging facility
  * Rate-limiting of discard messages
  * Expose logger defaults in the API
  * Use logging in `intel10g` and `nd_light`
