### PR TITLE
Add function find_devices to core/lib.lua

### DIFF
--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -4,7 +4,6 @@ local ffi = require("ffi")
 local C = ffi.C
 local getopt = require("lib.lua.alt_getopt")
 local syscall = require("syscall")
-local pci = require("lib.hardware.pci")
 require("core.clib_h")
 local bit = require("bit")
 local band, bor, bnot, lshift, rshift, bswap =

--- a/src/lib/hardware/README.md.src
+++ b/src/lib/hardware/README.md.src
@@ -73,6 +73,11 @@ enabled on device identified by *pciaddress* before calling his function.
 Closes memory mapped *file_descriptor* of sysfs resource file and unmaps
 it from *pointer* as returned by `pci.map_pci_memory`.
 
+— Function **pci.find_device**
+
+Return device's PCI address matching pattern. It can be useful to select a
+device's PCI address using a shorter form, for instance ':01:00.0' instead
+of '0000:01:00.0'.
 
 ### Register (lib.hardware.register)
 

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -146,8 +146,7 @@ local function find_devices(pattern)
    if #pci.devices == 0 then scan_devices() end
    local ret = {}
    for _,device in ipairs(pci.devices) do
-      if (device.usable and device.driver == 'apps.intel.intel_app' and
-         device.pciaddress:match(pattern)) then
+      if device.usable and device.pciaddress:match(pattern) then
          table.insert(ret, device.pciaddress)
       end
    end

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -142,6 +142,31 @@ function root_check ()
    lib.root_check("error: must run as root to access PCI devices")
 end
 
+local function find_devices(pattern)
+   if #pci.devices == 0 then scan_devices() end
+   local ret = {}
+   for _,device in ipairs(pci.devices) do
+      if (device.usable and device.driver == 'apps.intel.intel_app' and
+         device.pciaddress:match(pattern)) then
+         table.insert(ret, device.pciaddress)
+      end
+   end
+   return ret
+end
+
+-- Return device's PCI address matching pattern
+function find_device(pattern)
+   local devices = find_devices(pattern)
+   if #devices == 0 then
+      error('no devices matched pattern "'..pattern..'"')
+   elseif #devices == 1 then
+      return devices[1]
+   else
+      local devices_str = table.concat(devices, ' ')
+      error('multiple devices matched pattern "'..pattern..'":'..devices_str)
+   end
+end
+
 --- ### Selftest
 ---
 --- PCI selftest scans for available devices and performs our driver's


### PR DESCRIPTION
This function can be helpful to set a PCI address by a pattern, so either finding a device by a full address "0000:01:00.0" or a shorter address ":01:00.0" are valid.

This code is part of snabb-lwaftr. We think it can be useful for other modules too. Function by @andywingo.