### PR TITLE
Replace all-zero MAC address for 02:00:00:00:00:00

### DIFF
--- a/src/apps/socket/raw.lua
+++ b/src/apps/socket/raw.lua
@@ -40,8 +40,8 @@ function selftest ()
    local ethernet = require("lib.protocol.ethernet")
    local ipv6 = require("lib.protocol.ipv6")
    local dg_tx = datagram:new()
-   local src = ethernet:pton("00:00:00:00:00:01")
-   local dst = ethernet:pton("00:00:00:00:00:02")
+   local src = ethernet:pton("02:00:00:00:00:01")
+   local dst = ethernet:pton("02:00:00:00:00:02")
    local localhost = ipv6:pton("0:0:0:0:0:0:0:1")
    dg_tx:push(ipv6:new({src = localhost,
                         dst = localhost,

--- a/src/apps/vpn/README.md
+++ b/src/apps/vpn/README.md
@@ -34,7 +34,7 @@ representation.
 — Key **remote_mac**
 
 *Optional*. Remote MAC address as a string or in binary
-representation. Default is `00:00:00:00:00:00`.
+representation. Default is `02:00:00:00:00:00`.
 
 If *remote_mac* is not supplied, the `uplink` port needs to be connected
 to something that performs address resolution and overwrites the Ethernet

--- a/src/apps/vpn/README.md.src
+++ b/src/apps/vpn/README.md.src
@@ -45,7 +45,7 @@ representation.
 — Key **remote_mac**
 
 *Optional*. Remote MAC address as a string or in binary
-representation. Default is `00:00:00:00:00:00`.
+representation. Default is `02:00:00:00:00:00`.
 
 If *remote_mac* is not supplied, the `uplink` port needs to be connected
 to something that performs address resolution and overwrites the Ethernet

--- a/src/apps/vpn/vpws.lua
+++ b/src/apps/vpn/vpws.lua
@@ -52,7 +52,7 @@ function vpws:new(arg)
    -- overwrites the Ethernet header (e.g. the nd_light app)
    -- accordinly.
    o._encap.ether = ethernet:new({ src = conf.local_mac,
-                                   dst = conf.remote_mac or ethernet:pton('00:00:00:00:00:00'),
+                                   dst = conf.remote_mac or ethernet:pton('02:00:00:00:00:00'),
                                    type = 0x86dd })
    -- Pre-computed size of combined Ethernet and IPv6 header
    o._eth_ipv6_size = ethernet:sizeof() + ipv6:sizeof()


### PR DESCRIPTION
The motivation of this patch is to avoid potential problems because of using MAC addresses with special meanings. For instance, I recall a performance bug because of using a MAC address starting with '01:', which means multicast.

An all zero MAC address is a unicast globally administered address. According to [1], addresses with starting with '00:00:00' are reserved. I think is better to use one of the four family types of unicast locally administered MAC address available in the MAC address space: X2-XX-XX, X6-XX-XX, XA-XX-XX or XE-XX-XX. In this patch I picked 02:00:00:00:00:00.

[1] http://www.iana.org/assignments/ethernet-numbers/ethernet-numbers.xhtml