### PR TITLE
Use %x wildcard where possible

### DIFF
--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -197,7 +197,7 @@ end
 function hexundump(h, n)
    local buf = ffi.new('char[?]', n)
    local i = 0
-   for b in h:gmatch('[0-9a-fA-F][0-9a-fA-F]') do
+   for b in h:gmatch('%x%x') do
       buf[i] = tonumber(b, 16)
       i = i+1
       if i >= n then break end

--- a/src/lib/hardware/register.lua
+++ b/src/lib/hardware/register.lua
@@ -110,12 +110,12 @@ end
 
 --- returns true if an index string represents a range of registers
 function is_range (index)
-   return index:match('^%+[0-9xa-fA-F]+%*%d+%.%.%d+$') ~= nil
+   return index:match('^%+[%xx]+%*%d+%.%.%d+$') ~= nil
 end
 
 --- iterates the offset as defined in a range of registers
 function iter_range (offset, index)
-   local step,s,e =  string.match(index, '+([%dxa-fA-F]+)%*(%d+)%.%.(%d+)')
+   local step,s,e =  string.match(index, '+([%xx]+)%*(%d+)%.%.(%d+)')
    step, s, e = tonumber(step), tonumber(s), tonumber(e)
    local function iter(e, i)
       i = i + 1
@@ -130,7 +130,7 @@ function in_range (offset, index, n)
    offset = tonumber(offset)
    if offset == nil then return nil end
    n = tonumber(n) or 0
-   local step,s,e =  string.match(index, '+([%dxa-fA-F]+)%*(%d+)%.%.(%d+)')
+   local step,s,e =  string.match(index, '+([%xx]+)%*(%d+)%.%.(%d+)')
    if not step then return offset end
    step, s, e = tonumber(step), tonumber(s), tonumber(e)
    if s <= n and n <= e then
@@ -141,7 +141,7 @@ end
 
 --- formats a name for a specific member of a register range
 function range_name (index, name, i)
-   local step,s,e =  string.match(index, '+([%dxa-fA-F]+)%*(%d+)%.%.(%d+)')
+   local step,s,e =  string.match(index, '+([%xx]+)%*(%d+)%.%.(%d+)')
    local ndigits = #(tostring(tonumber(e)))
    local fmt = string.format('%%s[%%0%dd]', ndigits)
    return string.format(fmt, name, i)

--- a/src/lib/macaddress.lua
+++ b/src/lib/macaddress.lua
@@ -14,7 +14,7 @@ function mac_mt:new (m)
    end
    local macobj = mac_t()
    local i = 0;
-   for b in m:gmatch('[0-9a-fA-F][0-9a-fA-F]') do
+   for b in m:gmatch('%x%x') do
       if i == 6 then
          -- avoid out of bound array index
          return nil, "malformed MAC address: " .. m

--- a/src/lib/protocol/ethernet.lua
+++ b/src/lib/protocol/ethernet.lua
@@ -44,7 +44,7 @@ function ethernet:pton (p)
    local result = mac_addr_t()
    local i = 0
    for v in p:split(":") do
-      if string.match(v:lower(), '^[0-9a-f][0-9a-f]$') then
+      if string.match(v, '^%x%x$') then
          result[i] = tonumber("0x"..v)
       else
          error("invalid mac address "..p)


### PR DESCRIPTION
Some regular expressions use a customized regular expression [0-9a-fA-F] to match hexidecimal numbers. It is possible to use Lua's %x wildcard to do the same.

http://www.lua.org/pil/20.2.html