### PR TITLE
Cast T->mcode when passed as argument in setintfield

### DIFF
--- a/lib/luajit/src/lib_jit.c
+++ b/lib/luajit/src/lib_jit.c
@@ -300,7 +300,7 @@ LJLIB_CF(jit_util_traceinfo)
     setintfield(L, t, "link", T->link);
     setintfield(L, t, "nexit", T->nsnap);
     setintfield(L, t, "szmcode", T->szmcode);
-    setintfield(L, t, "mcode", T->mcode);
+    setintfield(L, t, "mcode", (int32_t)(intptr_t)T->mcode);
     setintfield(L, t, "mcloop", T->mcloop);
     setstrV(L, L->top++, lj_str_newz(L, jit_trlinkname[T->linktype]));
     lua_setfield(L, -2, "linktype");


### PR DESCRIPTION
So it gets rid of the warning:

```
lib_jit.c: In function ‘lj_cf_jit_util_traceinfo’:
lib_jit.c:303:32: warning: passing argument 4 of ‘setintfield’ makes integer from pointer without a cast
     setintfield(L, t, "mcode", T->mcode);
```

`T->mcode` is a _void*_, size of _long_ is wide enough to hold a _void*_.