### PR TITLE
nd_light: Fix use after free bug in neighbor solicitation.

### DIFF
--- a/src/apps/ipv6/nd_light.lua
+++ b/src/apps/ipv6/nd_light.lua
@@ -136,6 +136,9 @@ function nd_light:new (arg)
    -- Timer for retransmits of neighbor solicitations
    nh.timer_cb = function (t)
                     local nh = o._next_hop
+                    -- If nh.packet is nil the app was stopped and we
+                    -- bail out.
+                    if nh.packet then return nil end
                     o._logger:log(string.format("Sending neighbor solicitation for next-hop %s",
                                                 ipv6:ntop(conf.next_hop)))
                     link.transmit(o.output.south, packet.clone(nh.packet))
@@ -316,7 +319,9 @@ end
 -- Free static packets on `stop'.
 function nd_light:stop ()
    packet.free(self._next_hop.packet)
+   self._next_hop.packet = nil
    packet.free(self._sna.packet)
+   self._sna.packet = nil
 end
 
 function selftest ()

--- a/src/apps/ipv6/nd_light.lua
+++ b/src/apps/ipv6/nd_light.lua
@@ -138,7 +138,7 @@ function nd_light:new (arg)
                     local nh = o._next_hop
                     -- If nh.packet is nil the app was stopped and we
                     -- bail out.
-                    if nh.packet then return nil end
+                    if not nh.packet then return nil end
                     o._logger:log(string.format("Sending neighbor solicitation for next-hop %s",
                                                 ipv6:ntop(conf.next_hop)))
                     link.transmit(o.output.south, packet.clone(nh.packet))


### PR DESCRIPTION
This fixes a “use after free” bug (#643) in nd_light. The bug only surfaced when using the Solarflare driver but is indeed unrelated. I want to highlight a pattern that I think is close to a whole class of bugs:

```
 function nd_light:stop ()
    packet.free(self._next_hop.packet)
+   self._next_hop.packet = nil
    packet.free(self._sna.packet)
+   self._sna.packet = nil
 end
```

So what I did here previously (I wrote the bug in the first place) is to free “static” packets when the app is stopped. In itself this is important as to not leak memory. The nd_light app specifically launches a timer that will send `self._next_hop.packet` periodically. What happens when you start nd_light and stop it right away? The timer gets activated, the packet is freed, the timer runs, attempts to clone a packet which was already freed: wham, segmentation fault.

As a response I added explicit statements unbinding the slots that hold pointers to freed packets. I think this is an important lesson learned: **Do not keep invalid pointers around.** If you free a packet held in a variable that can be accessed outside the lexical scope (for instance an object slot), null it right away. That way you will get a meaningful error message instead of a segmentation fault.