### PR TITLE
lib.pci: Support short/canonical ("01:00.0") PCI addresses

### DIFF
--- a/src/lib/hardware/README.md
+++ b/src/lib/hardware/README.md
@@ -23,6 +23,19 @@ An array of supported hardware devices. Must be populated by calling
 `pci.scan_devices`. Each entry is a table as returned by
 `pci.device_info`.
 
+— Function **pci.canonical** *pciaddress*
+
+Returns the canonical representation of a PCI address. The canonical
+representation is preferred internally in Snabb Switch and for
+presenting to users. It shortens addresses with leading zeros like
+this: `0000:01:00.0` becomes `01:00.0`.
+
+— Function **pci.qualified** *pciaddress*
+
+Returns the fully qualified representation of a PCI address. Fully
+qualified addresses have the form `0000:01:00.0` and so this function
+undoes any abbreviation in the canonical representation.
+
 — Function **pci.scan_devices**
 
 Scans for available PCI devices and populates the `pci.devices` table.

--- a/src/lib/hardware/README.md.src
+++ b/src/lib/hardware/README.md.src
@@ -23,6 +23,19 @@ An array of supported hardware devices. Must be populated by calling
 `pci.scan_devices`. Each entry is a table as returned by
 `pci.device_info`.
 
+— Function **pci.canonical** *pciaddress*
+
+Returns the canonical representation of a PCI address. The canonical
+representation is preferred internally in Snabb Switch and for
+presenting to users. It shortens addresses with leading zeros like
+this: `0000:01:00.0` becomes `01:00.0`.
+
+— Function **pci.qualified** *pciaddress*
+
+Returns the fully qualified representation of a PCI address. Fully
+qualified addresses have the form `0000:01:00.0` and so this function
+undoes any abbreviation in the canonical representation.
+
 — Function **pci.scan_devices**
 
 Scans for available PCI devices and populates the `pci.devices` table.

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -67,7 +67,7 @@ function is_device_suitable (pcidev, patterns)
       return true
    end
    for _, pattern in ipairs(patterns) do
-      if pcidev.pciaddress:gmatch(pattern)() then
+      if pci.qualified(pcidev.pciaddress):gmatch(pattern)() then
          return true
       end
    end


### PR DESCRIPTION
Proposed alternative to #657 after tomatoes were thrown in response to my more complicated proposal.

Adds these two functions:

- `pci.canonical(address)` => returns address in short canonical format (`01:00.0`)
- `pci.qualified(address)` => returns address in fully qualified format (`0000:01:00.0`)

with the intention that users can specify either format and Snabb Switch will prefer the canonical format internally but expand to the qualified format when needed (e.g. for resolving sysfs paths).

This is a user visible change. The PCI device scan and selftest now uses canonical addresses:

    $ sudo ./snabb snsh -t lib.hardware.pci
    selftest: pci
    pciaddress    vendor  device  interface  status    driver      usable
    01:00.0       0x8086  0x10fb  p1p1       down      apps.intel.intel_app yes
    01:00.1       0x8086  0x10fb  p1p2       down      apps.intel.intel_app yes
    02:00.0       0x8086  0x10fb  p2p1       down      apps.intel.intel_app yes
    02:00.1       0x8086  0x10fb  p2p2       down      apps.intel.intel_app yes
    03:00.0       0x8086  0x10fb  p3p1       down      apps.intel.intel_app yes
    03:00.1       0x8086  0x10fb  -          -         apps.intel.intel_app yes
    81:00.0       0x8086  0x10fb  p5p1       down      apps.intel.intel_app yes
    81:00.1       0x8086  0x10fb  p5p2       down      apps.intel.intel_app yes
    82:00.0       0x8086  0x10fb  p6p1       down      apps.intel.intel_app yes
    82:00.1       0x8086  0x10fb  p6p2       down      apps.intel.intel_app yes

and software now accepts either format in parameters:

    $ sudo SNABB_PCI0=01:00.0 SNABB_PCI1=0000:01:00.1 ./snabb snsh -t apps.intel.intel_app
    selftest: intel_app
    100 VF initializations:

    Running iterated VMDq test...
    test #  1: VMDq VLAN=101; 100ms burst. packet sent: 628,830
    test #  2: VMDq VLAN=102; 100ms burst. packet sent: 1,745,985
    test #  3: VMDq VLAN=103; 100ms burst. packet sent: 2,891,700

This change can potentially break software that depends on always having qualified paths: that would now be considered a bug. (This PR includes a fix for such a problem in packetblaster.)