### PR TITLE
Fix bugs in PMU code

### DIFF
--- a/src/lib/pmu.lua
+++ b/src/lib/pmu.lua
@@ -199,8 +199,13 @@ function setup (patterns)
       table.sort(set)
    end
    local ndropped = math.max(0, #set - pmu_x86.ngeneral)
-   if ndropped > 0 then set[pmu_x86.ngeneral+1] = nil end
+   while (#set - pmu_x86.ngeneral) > 0 do table.remove(set) end
    local cpu = cpu_set()[1]
+   -- All available counters are globally enabled
+   -- (IA32_PERF_GLOBAL_CTRL).
+   writemsr(cpu, 0x38f,
+            bit.bor(bit.lshift(0x3ULL, 32),
+                    bit.lshift(1ULL, pmu_x86.ngeneral) - 1))
    -- Enable all fixed-function counters (IA32_FIXED_CTR_CTRL)
    writemsr(cpu, 0x38d, 0x333)
    for n = 0, #set-1 do


### PR DESCRIPTION
There were two bugs in the PMU code.  The first was that if the events
you select matched more than pmu_x86_ngeneral counters, the set of
events was being incorrectly truncated.  This would later manifest as an
error when we try to do defs[set[j+1]], as some random element in the
middle of `set' could be nil.

The other bug was that the global IA32_PERF_GLOBAL_CTRL register wasn't
being initialized.  One symptom could be that any given counter wasn't
counting -- for me it was the cycles fixed-function counter.  We didn't
observe this in the past because this is global state that could have
gotten initialized by any other program -- perhaps a previous invocation
of `perf`.