### PR TITLE
Fix build with Musl libc

### DIFF
--- a/gcc-preinclude.h
+++ b/gcc-preinclude.h
@@ -2,7 +2,12 @@
 // See: http://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html
 //      https://rjpower9000.wordpress.com/2012/04/09/fun-with-shared-libraries-version-glibc_2-14-not-found/
 
+#define _GNU_SOURCE 1
+
+#include <features.h>
+
 #ifndef __ASSEMBLER__
+#ifdef __GLIBC__
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
 #endif
-
+#endif

--- a/src/apps/solarflare/ef_vi.h
+++ b/src/apps/solarflare/ef_vi.h
@@ -1,3 +1,4 @@
+#include <time.h>
 
 /* etherfabric/base.h */
 

--- a/src/apps/vhost/vhost_user.c
+++ b/src/apps/vhost/vhost_user.c
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/src/core/lib.c
+++ b/src/core/lib.c
@@ -2,7 +2,7 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 
 /* Return the current wall-clock time in nanoseconds. */
 uint64_t get_time_ns()

--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -9,7 +9,7 @@
 // virtual addresses (remove the tag bits) and to test addresses for
 // validity (check the tag bits).
 
-#define _GNU_SOURCE
+#define _GNU_SOURCE 1
 
 #include <assert.h>
 #include <fcntl.h>

--- a/src/lib/traceprof/traceprof.c
+++ b/src/lib/traceprof/traceprof.c
@@ -1,8 +1,9 @@
 // Location where the next instruction pointer value will be stored.
 
+#define _GNU_SOURCE 1
+
 #include <assert.h>
 #include <stdio.h>
-#define __USE_GNU
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/time.h>


### PR DESCRIPTION
Minor portability fixes that let Snabb build under Musl libc, tested on Alpine Linux.