### PR TITLE
README.md: Fix and update packetblaster example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For example, to install on the local machine and use as a load generator:
 
 ```
 $ cp src/snabb /usr/local/bin/
-$ sudo snabb packetblaster capture.pcap 0000:01:00.0
+$ sudo snabb packetblaster replay capture.pcap 01:00.0
 ```
 
 ## How do I get involved?


### PR DESCRIPTION
Fix: had missed the 'replay' argument.

Update: use shorter canonical PCI device name (without leading 0000:).