### PR TITLE
make PREFIX work like expected, and use DESTDIR for that

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ LUASRC = $(wildcard src/lua/*.lua)
 LUAOBJ = $(LUASRC:.lua=.o)
 CSRC   = $(wildcard src/c/*.c)
 COBJ   = $(CSRC:.c=.o)
+PREFIX = /usr/local
 
 LUAJIT_CFLAGS := -include $(CURDIR)/gcc-preinclude.h
 
@@ -22,7 +23,7 @@ all: $(LUAJIT) $(SYSCALL) $(PFLUA)
 	cd src && $(MAKE)
 
 install: all
-	install -D src/snabb ${PREFIX}/usr/local/bin/snabb
+	install -D src/snabb ${DESTDIR}${PREFIX}/bin/snabb
 
 clean:
 	(cd lib/luajit && $(MAKE) clean)


### PR DESCRIPTION
PREFIX is usually used to indicate installation in /, /usr or /usr/local, while DESTDIR is used when creating packages etc. This is how autocrap does it and a lot of packagers expect this behavior.