### PR TITLE
page pointers portable to 32bit platforms

### DIFF
--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -29,18 +29,18 @@
 
 // Convert from virtual addresses in our own process address space to
 // physical addresses in the RAM chips.
-uint64_t virtual_to_physical(void *ptr)
+uint64_t virtual_to_physical(uintptr_t *ptr)
 {
-  uint64_t virt_page;
+  uintptr_t virt_page;
   static int pagemap_fd;
-  virt_page = ((uint64_t)ptr) / 4096;
+  virt_page = ((uintptr_t)ptr) / 4096;
   if (pagemap_fd == 0) {
     if ((pagemap_fd = open("/proc/self/pagemap", O_RDONLY)) <= 0) {
       perror("open pagemap");
       return 0;
     }
   }
-  uint64_t data;
+  uintptr_t data;
   int len;
   len = pread(pagemap_fd, &data, sizeof(data), virt_page * sizeof(uint64_t));
   if (len != sizeof(data)) {
@@ -80,7 +80,7 @@ uint64_t virtual_to_physical(void *ptr)
 void *allocate_huge_page(int size)
 {
   int shmid = -1;
-  uint64_t physical_address, virtual_address;
+  uintptr_t physical_address, virtual_address;
   void *tmpptr = MAP_FAILED;  // initial kernel assigned virtual address
   void *realptr = MAP_FAILED; // remapped virtual address
   shmid = shmget(IPC_PRIVATE, size, SHM_HUGETLB | IPC_CREAT | SHM_R | SHM_W);


### PR DESCRIPTION
Use the appropriate pointer type `uintptr_t`.

A 32bit build will fail with the following error due to -Werror:
```
core/memory.c: In function 'virtual_to_physical':
core/memory.c:36:16: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
   virt_page = ((uint64_t)ptr) / 4096;
                ^
...
core/memory.c:51:5: error: format '%lx' expects argument of type 'long unsigned int', but argument 4 has type 'uint64_t' [-Werror=format=]
core/memory.c: In function 'allocate_huge_page':
core/memory.c:93:26: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
   realptr = shmat(shmid, (void*)virtual_address, 0);
                          ^
```
This patch is split out from #483, and fixes the problem by using an int type that changes size with the page size.