### PR TITLE
[draft] lib.blit: Introduce API for optimized "blitter" for Virtio-net DMA

### DIFF
--- a/src/lib/blit.lua
+++ b/src/lib/blit.lua
@@ -1,0 +1,33 @@
+-- blit.lua - offload engine for memory operations
+
+module(..., package.seeall)
+
+local ffi = require("ffi")
+
+-- The blit module provides "blitter" operation to offload
+-- performance-critical memory operations. The API allows scheduling a
+-- series of operations, that can be performed at any time and in any
+-- order, and then executing a "barrier" to wait for completion.
+
+-- The implementation in this file is very basic but could be extended
+-- in the future to take advantage of the flexibility afforded by the
+-- API to perform special optimizations (for example parallel memory
+-- copies to amortize cache latency, etc).
+
+function copy (dst, src, len)
+   -- Trivial implementation: simply do an immediate memory copy.
+   ffi.copy(dst, src, len)
+end
+
+-- Wait until all copies have completed.
+function barrier ()
+   -- No-op because the copies were already executed eagerly.
+end
+
+function selftest ()
+   print("selftest: blit")
+   -- It would be valuable to have an extensive selftest function to
+   -- make it easy to develop and test new optimized blitter
+   -- implementations.
+   print("selftest: ok")
+end

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -11,6 +11,7 @@ local packet    = require("core.packet")
 local timer     = require("core.timer")
 local vq        = require("lib.virtio.virtq")
 local checksum  = require("lib.checksum")
+local blit      = require("lib.blit")
 local ffi       = require("ffi")
 local C         = ffi.C
 local band      = bit.band
@@ -106,6 +107,7 @@ end
 function VirtioNetDevice:poll_vring_receive ()
    -- RX
    self:receive_packets_from_vm()
+   blit.barrier()
    self:rx_signal_used()
 end
 
@@ -139,7 +141,8 @@ function VirtioNetDevice:rx_buffer_add(rx_p, addr, len)
    local addr = self:map_from_guest(addr)
    local pointer = ffi.cast(char_ptr_t, addr)
 
-   packet.append(rx_p, pointer, len)
+   rx_p.length = rx_p.length + len
+   blit.copy(rx_p, pointer, len)
    return len
 end
 
@@ -174,6 +177,7 @@ end
 function VirtioNetDevice:poll_vring_transmit ()
    -- RX
    self:transmit_packets_to_vm()
+   blit.barrier()
    self:tx_signal_used()
 end
 
@@ -239,7 +243,7 @@ function VirtioNetDevice:tx_buffer_add(tx_p, addr, len)
    local pointer = ffi.cast(char_ptr_t, addr)
 
    assert(tx_p.length <= len)
-   ffi.copy(pointer, tx_p.data, tx_p.length)
+   blit.copy(pointer, tx_p.data, tx_p.length)
 
    return tx_p.length
 end
@@ -288,7 +292,7 @@ function VirtioNetDevice:tx_buffer_add_mrg_rxbuf(tx_p, addr, len)
    local to_copy = math.min(tx_p.length - self.tx.data_sent, len + adjust)
 
    -- copy the data to the adjusted pointer
-   ffi.copy(pointer - adjust, tx_p.data + self.tx.data_sent, to_copy)
+   ffi.copy(tx_p.data + self.tx.data_sent, pointer - adjust, to_copy)
 
    -- update the num_buffers in the first virtio header
    self.tx.tx_mrg_hdr[0].num_buffers = self.tx.tx_mrg_hdr[0].num_buffers + 1


### PR DESCRIPTION
Just wanted to share this fun hack for a software [blitter](https://en.wikipedia.org/wiki/Blitter) that I am working on in connection with #710.

The idea is to isolate the virtio-net memory copy operations from the rest of the vring processing so that they can be optimized separately. See the individual commit comments for more details.

I have started to experiment with writing an optimized batch-mode version of the blitter in assembler. The initial results are encouraging but it is early days yet and I don't know which aspects of the design are important. See [gist](https://gist.github.com/lukego/450e108c9c9cf420252d) for rough notes and code.

I started looking at this in the context of debugging #665.

If there is a suitable online betting site then I am willing to wager that a suitable blit subroutine will speed up the copy operations for Virtio-net by 2x - 4x :smile: because the performance we see with `memcpy` seems nowhere near the capabilities of the processor.