### PR TITLE
Fixed a bug where string couldn't be app arguments

### DIFF
--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -107,7 +107,7 @@ end
 
 -- Load Lua value from string.
 function load_string (string)
-   return loadstring("return "..string)
+   return loadstring("return "..string)()
 end
 
 -- Read a Lua conf from file and return value.
@@ -700,6 +700,8 @@ function selftest ()
    assert(true == equal({foo="bar"}, {foo="bar"}))
    assert(false == equal({foo="bar"}, {foo="bar", baz="foo"}))
    assert(false == equal({foo="bar", baz="foo"}, {foo="bar"}))
+   print("Testing load_string")
+   assert(equal(load_string("{1,2}"), {1,2}), "load_string failed.")
    print("Testing load/store_conf")
    local conf = { foo="1", bar=42, arr={2,"foo",4}}
    local testpath = "/tmp/snabb_lib_test_conf"

--- a/src/program/snabbnfv/neutron2snabb/neutron2snabb.lua
+++ b/src/program/snabbnfv/neutron2snabb/neutron2snabb.lua
@@ -242,7 +242,7 @@ end
 function selftest ()
    print("selftest: neutron2snabb")
    local function checkrule (rule, filter)
-      local got = rulestofilter(lib.load_string(rule)(), 'ingress')
+      local got = rulestofilter(lib.load_string(rule), 'ingress')
       if got ~= filter then
          print(([[Unexpected translation of %s"
   Expected: %q


### PR DESCRIPTION
`lib.load_string` failed to properly call Lua's `loadstring` built-in.