### PR TITLE
core.memory: get the page size from sysconf

### DIFF
--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -79,7 +79,6 @@ function get_huge_page_size ()
    return tonumber(hugesize) * 1024
 end
 
-base_page_size = 4096
 -- Huge page size in bytes
 huge_page_size = get_huge_page_size()
 -- Address bits per huge page (2MB = 21 bits; 1GB = 30 bits)


### PR DESCRIPTION
The page size is hardcoded to 4K, which is a problem on systems which
define different value for it. Use sysconf(_SC_PAGESIZE) to determine
the actual page size.

base_page_size is removed from memory.lua since is not used.