### PR TITLE
Globally use '#!/usr/bin/env <shell>' hashbang line

### DIFF
--- a/src/apps/solarflare/selftest.sh
+++ b/src/apps/solarflare/selftest.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./snabb snabbmark solarflare 10e6 128 10

--- a/src/apps/tap/selftest.sh
+++ b/src/apps/tap/selftest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 sudo ip netns add snabbtest || exit $TEST_SKIPPED
 sudo ip netns exec snabbtest ip link add name snabbtest type bridge
 sudo ip netns exec snabbtest ip link set up dev snabbtest

--- a/src/bench/basic1-100e6
+++ b/src/bench/basic1-100e6
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 out=$(./snabb snabbmark basic1 100e6)
 # Extract floating point Mpps number from output.

--- a/src/bench/packetblaster-64
+++ b/src/bench/packetblaster-64
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 [ ! -z "$SNABB_PCI_INTEL0" ] || exit 1

--- a/src/bench/packetblaster-synth-64
+++ b/src/bench/packetblaster-synth-64
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e 
 
 [ ! -z "$SNABB_PCI_INTEL0" ] || exit 1

--- a/src/bench/snabbnfv-iperf-1500
+++ b/src/bench/snabbnfv-iperf-1500
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 out=$(program/snabbnfv/selftest.sh bench)
 # Extract floating point Gbits number from output.

--- a/src/bench/snabbnfv-iperf-jumbo
+++ b/src/bench/snabbnfv-iperf-jumbo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 out=$(program/snabbnfv/selftest.sh bench jumbo)
 # Extract floating point Gbits number from output.

--- a/src/bench/snabbnfv-loadgen-dpdk
+++ b/src/bench/snabbnfv-loadgen-dpdk
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 out=$(timeout 120 program/snabbnfv/packetblaster_bench.sh)
 # Extract floating point Mpps number from output.

--- a/src/doc/genbook.sh
+++ b/src/doc/genbook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This shell scripts generates the top-level Markdown structure of the
 # Snabb Switch book.

--- a/src/lib/watchdog/selftest.sh
+++ b/src/lib/watchdog/selftest.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 ./snabb snsh ./lib/watchdog/selftest_design alert
 if [ $? != 0 ]; then exit 1; fi

--- a/src/program/packetblaster/selftest.sh
+++ b/src/program/packetblaster/selftest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "selftest: packetblaster"
 export PCIADDR=$SNABB_PCI_INTEL0

--- a/src/program/snabbnfv/neutron2snabb/selftest.sh
+++ b/src/program/snabbnfv/neutron2snabb/selftest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "selftest: neutron2snabb/selftest.sh"
 

--- a/src/program/snabbnfv/neutron_sync_agent/neutron_sync_agent.sh
+++ b/src/program/snabbnfv/neutron_sync_agent/neutron_sync_agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Neutron synchronization slave process to run on the Compute Nodes.
 

--- a/src/program/snabbnfv/neutron_sync_master/neutron_sync_master.sh
+++ b/src/program/snabbnfv/neutron_sync_master/neutron_sync_master.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Neutron synchronization master process to run on the Network Node.
 

--- a/src/program/snabbnfv/packetblaster_bench.sh
+++ b/src/program/snabbnfv/packetblaster_bench.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export SKIPPED_CODE=43
 

--- a/src/program/snabbnfv/selftest.sh
+++ b/src/program/snabbnfv/selftest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SKIPPED_CODE=43
 

--- a/src/scripts/bench.sh
+++ b/src/scripts/bench.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function n_times {
     for i in $(seq $1); do

--- a/src/scripts/process-markdown
+++ b/src/scripts/process-markdown
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Markdown preprocessor.
 #

--- a/src/scripts/sysv/init.d/snabb-nfv-sync-agent
+++ b/src/scripts/sysv/init.d/snabb-nfv-sync-agent
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 
 ### BEGIN INIT INFO

--- a/src/scripts/sysv/init.d/snabb-nfv-sync-master
+++ b/src/scripts/sysv/init.d/snabb-nfv-sync-master
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 
 ### BEGIN INIT INFO

--- a/src/scripts/sysv/init.d/snabb-nfv-traffic
+++ b/src/scripts/sysv/init.d/snabb-nfv-traffic
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 
 ### BEGIN INIT INFO

--- a/src/selftest.sh
+++ b/src/selftest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "selftest: ./snabb binary portability"
 echo "Scanning for symbols requiring GLIBC > 2.7"
 if objdump -T snabb | \


### PR DESCRIPTION
Convert all shell scripts from having path dependencies like:

    #!/bin/bash
to

    #!/usr/bin/env bash

The immediate utility of this change is to fix annoying breakage on NixOS. For example, now `make doc/snabbswitch.html` works on lab servers.

Exception is that I did not descend into subdirectories of dependencies e.g. ljsyscall and pflua.

I made the changes with an Emacs macro in the hope of avoiding an unfortunate typo that will break something.