### PR TITLE
Simplify core.memory API

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -333,48 +333,23 @@ Allocate packet and fill it with the contents of *string*.
 
 ## Memory (core.memory)
 
-Snabb Switch does two things specially when it comes to memory: It
-runs with a fixed physical memory map and it allocates *huge pages*
-from the operating system.
+Snabb Switch allocates special
+[DMA](https://en.wikipedia.org/wiki/Direct_memory_access) memory that
+can be accessed directly by network cards. The important
+characteristic of DMA memory is being located in contiguous physical
+memory at a stable address.
 
-Running with a fixed memory map means that every virtual address in the
-Snabb Switch process has a fixed *physical address* in the RAM
-chips. This means that we are always able to convert from a virtual
-address in our process to a physical address that other hardware (for
-example, a network card) can use for DMA.
+— Function **memory.dma_alloc** *bytes*
 
-Huge pages (also known as *HugeTLB pages*) are how we allocate large
-amounts of contiguous memory, typically 2MB at a time. Hardware devices
-sometimes require this, for example a network card's *descriptor ring*
-may require a list of pointers to available buffers in physical memory.
+Returns a pointer to *bytes* of new DMA memory.
 
-— Variable **memory.chunks**
+— Function **memory.virtual_to_physical** *pointer*
 
-List of all allocated huge pages. Read-only. Each huge page is
-represented by a table with the following keys:
-
-* `pointer` - Virtual address
-* `physical` - Physical address
-* `size` -  Size in bytes
-* `used` - Bytes used
+Returns the physical address (`uint64_t`) the DMA memory at *pointer*.
 
 — Variable **memory.huge_page_size**
 
 Size of a single huge page in bytes. Read-only.
-
-— Variable **huge_page_bits**
-
-Number of address bits per huge page. Read-only.
-
-— Function **memory.dma_alloc** *bytes*
-
-Allocate *bytes* of DMA-friendly memory. Returns virtual memory pointer,
-physical address, and actual size.
-
-— Function **memory.virtual_to_physical** *virtual_address*
-
-Returns the physical address of memory at *virtual_address*.
-
 
 
 ## Lib (core.lib)

--- a/src/README.md.src
+++ b/src/README.md.src
@@ -373,7 +373,7 @@ Returns a pointer to *bytes* of new DMA memory.
 
 Returns the physical address (`uint64_t`) the DMA memory at *pointer*.
 
-— Variable **memory.huge_page_size** [**DEPRECATED**]
+— Variable **memory.huge_page_size**
 
 Size of a single huge page in bytes. Read-only.
 

--- a/src/README.md.src
+++ b/src/README.md.src
@@ -359,55 +359,23 @@ Allocate packet and fill it with the contents of *string*.
 
 ## Memory (core.memory)
 
-Snabb Switch does two things specially when it comes to memory: It
-runs with a fixed physical memory map and it allocates *huge pages*
-from the operating system.
-
-Running with a fixed memory map means that every virtual address in the
-Snabb Switch process has a fixed *physical address* in the RAM
-chips. This means that we are always able to convert from a virtual
-address in our process to a physical address that other hardware (for
-example, a network card) can use for DMA.
-
-Huge pages (also known as *HugeTLB pages*) are how we allocate large
-amounts of contiguous memory, typically 2MB at a time. Hardware devices
-sometimes require this, for example a network card's *descriptor ring*
-may require a list of pointers to available buffers in physical memory.
-
-— Variable **memory.chunks**
-
-List of all allocated huge pages. Read-only. Each huge page is
-represented by a table with the following keys:
-
-* `pointer` - Virtual address
-* `physical` - Physical address
-* `size` -  Size in bytes
-* `used` - Bytes used
-
-— Variable **memory.dma_min_addr**
-
-— Variable **memory.dma_max_addr**
-
-Lowest and highest addresses of valid DMA memory. Useful information for
-creating memory maps. Read-only.
-
-— Variable **memory.huge_page_size**
-
-Size of a single huge page in bytes. Read-only.
-
-— Variable **huge_page_bits**
-
-Number of address bits per huge page. Read-only.
+Snabb Switch allocates special
+[DMA](https://en.wikipedia.org/wiki/Direct_memory_access) memory that
+can be accessed directly by network cards. The important
+characteristic of DMA memory is being located in contiguous physical
+memory at a stable address.
 
 — Function **memory.dma_alloc** *bytes*
 
-Allocate *bytes* of DMA-friendly memory. Returns virtual memory pointer,
-physical address, and actual size.
+Returns a pointer to *bytes* of new DMA memory.
 
-— Function **memory.virtual_to_physical** *virtual_address*
+— Function **memory.virtual_to_physical** *pointer*
 
-Returns the physical address of memory at *virtual_address*.
+Returns the physical address (`uint64_t`) the DMA memory at *pointer*.
 
+— Variable **memory.huge_page_size** [**DEPRECATED**]
+
+Size of a single huge page in bytes. Read-only.
 
 
 ## Lib (core.lib)

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -328,20 +328,6 @@ function VirtioNetDevice:tx_signal_used()
    end
 end
 
-local pagebits = memory.huge_page_bits
-
--- Cache of the latest referenced physical page.
-function VirtioNetDevice:translate_physical_addr (addr)
-   local page = bit.rshift(addr, pagebits)
-   if page == self.last_virt_page then
-      return addr + self.last_virt_offset
-   end
-   local phys = memory.virtual_to_physical(addr)
-   self.last_virt_page = page
-   self.last_virt_offset = phys - addr
-   return phys
-end
-
 function VirtioNetDevice:map_from_guest (addr)
    local result
    local m = self.mem_table[0]


### PR DESCRIPTION
Streamline the core.memory API:

- Rewrite the blurb.
- Keep dma_alloc() and virtual_to_physical().
- Remove dma_min_addr and dma_max_addr (unused).
- Deprecate huge_page_size (used but should it be?)

Backstory here is that the core.memory module has exported low-level information to other modules: the VFIO module (since removed) that needed to whitelist all DMA memory with the kernel, a /dev/vhost-net accelerator for tap devices (since removed) that also needed to whitelist all packet memory, and to a lesser extent the vhost-user implementation (that is still alive and well but may be overusing the memory API e.g. in dead code that should be removed).

Adding the deprecation note on "huge_page_size" may or may not be a good idea. Have to look more closely at the usage and clarify with a later commit.