### PR TITLE
Pass only interface name to syscall.util.if_nametoindex()

### DIFF
--- a/src/apps/socket/raw.lua
+++ b/src/apps/socket/raw.lua
@@ -14,14 +14,13 @@ RawSocket = {}
 
 function RawSocket:new (ifname)
    assert(ifname)
+   local index, err = S.util.if_nametoindex(ifname)
+   if not index then error(err) end
+
    local tp = h.htons(c.ETH_P["ALL"])
    local sock, err = S.socket(c.AF.PACKET, bit.bor(c.SOCK.RAW, c.SOCK.NONBLOCK), tp)
    if not sock then error(err) end
-   local index, err = S.util.if_nametoindex(ifname, sock)
-   if err then
-      S.close(sock)
-      error(err)
-   end
+
    local addr = t.sockaddr_ll{sll_family = c.AF.PACKET, sll_ifindex = index, sll_protocol = tp}
    local ok, err = S.bind(sock, addr)
    if not ok then


### PR DESCRIPTION
The `syscall.util.if_nametoindex()` only needs to be passed the name of the interface. The version of the function which accepts an open socket as second argument is internal to `ljsyscall`, and not even exported to client code.

Also, this moves the call to `syscall.util.if_nametoindex()` to the top of `RawSocket:new()` to simplify error handling: this way one less explicit call to `syscall.close()` is needed in case of errors.