### PR TITLE
Clearly mark all Apache 2.0 licensed code as such

### DIFF
--- a/src/apps/basic/basic_apps.lua
+++ b/src/apps/basic/basic_apps.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local app = require("core.app")

--- a/src/apps/bridge/base.lua
+++ b/src/apps/bridge/base.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Base class for an Ethernet bridge with split-horizon semantics.
 --
 -- A bridge conists of any number of ports, each of which is a member

--- a/src/apps/bridge/flooding.lua
+++ b/src/apps/bridge/flooding.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- This class derives from lib.bridge.base and implements the simplest
 -- possible bridge, which floods a packet arriving on a port to all
 -- destination ports within its scope according to the split-horizon

--- a/src/apps/bridge/learning.h
+++ b/src/apps/bridge/learning.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 /* Type for port and split-horizon group handles */
 typedef uint16_t handle_t;
 

--- a/src/apps/bridge/learning.lua
+++ b/src/apps/bridge/learning.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- This class derives from lib.bridge.base and implements a "learning
 -- bridge" using a MAC address table provided by apps.bridge.mac_table
 -- to store the set of source addresses of packets arriving on all

--- a/src/apps/bridge/mac_table.c
+++ b/src/apps/bridge/mac_table.c
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 #include <inttypes.h>
 #include "learning.h"
 

--- a/src/apps/bridge/mac_table.lua
+++ b/src/apps/bridge/mac_table.lua
@@ -1,3 +1,4 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
 --
 -- This module implements a MAC address table as part of the learning
 -- bridge app (apps.bridge.learning).  It associates a MAC address

--- a/src/apps/csv.lua
+++ b/src/apps/csv.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local app = require("core.app")

--- a/src/apps/intel/intel.h
+++ b/src/apps/intel/intel.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 // RX descriptor written by software.
 struct rx_desc {
    uint64_t address;    // 64-bit address of receive buffer

--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 --- Device driver for the Intel 82599 10-Gigabit Ethernet controller.
 --- This is one of the most popular production 10G Ethernet
 --- controllers on the market and it is readily available in

--- a/src/apps/intel/intel1g.lua
+++ b/src/apps/intel/intel1g.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- intel1g: Device driver app for Intel 1G network cards
 -- 
 -- This is a device driver for Intel i210, i350 families of 1G network cards.

--- a/src/apps/intel/intel_app.lua
+++ b/src/apps/intel/intel_app.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local zone = require("jit.zone")

--- a/src/apps/intel/loadgen.lua
+++ b/src/apps/intel/loadgen.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local ffi = require("ffi")

--- a/src/apps/ipv6/nd_light.lua
+++ b/src/apps/ipv6/nd_light.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- This app implements a small subset of IPv6 neighbor discovery
 -- (RFC4861).  It has two ports, north and south.  The south port
 -- attaches to a port on which ND must be performed.  The north port

--- a/src/apps/ipv6/ns_responder.lua
+++ b/src/apps/ipv6/ns_responder.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- This app acts as a responder for neighbor solicitaions for a
 -- specific target address and as a relay for all other packets.  It
 -- has two ports, north and south.  The south port attaches to a port

--- a/src/apps/keyed_ipv6_tunnel/tunnel.lua
+++ b/src/apps/keyed_ipv6_tunnel/tunnel.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 -- http://tools.ietf.org/html/draft-mkonstan-keyed-ipv6-tunnel-01

--- a/src/apps/packet_filter/conntrack.lua
+++ b/src/apps/packet_filter/conntrack.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- conntrack.lua -- Connection tracking for IPv4/IPv6 TCP/UDP sessions
 --
 -- This module exposes the following API:

--- a/src/apps/packet_filter/pcap_filter.lua
+++ b/src/apps/packet_filter/pcap_filter.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local app = require("core.app")

--- a/src/apps/pcap/pcap.lua
+++ b/src/apps/pcap/pcap.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local ffi = require("ffi")

--- a/src/apps/rate_limiter/rate_limiter.lua
+++ b/src/apps/rate_limiter/rate_limiter.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local app = require("core.app")

--- a/src/apps/socket/raw.lua
+++ b/src/apps/socket/raw.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local S = require("syscall")

--- a/src/apps/solarflare/ef_vi.h
+++ b/src/apps/solarflare/ef_vi.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 #include <time.h>
 
 /* etherfabric/base.h */

--- a/src/apps/solarflare/poll.c
+++ b/src/apps/solarflare/poll.c
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 /* poll.c - Poll multiple ef_vi interfaces in one FFI call to save on FFI overhead */
 
 #include <stdint.h>

--- a/src/apps/solarflare/solarflare.lua
+++ b/src/apps/solarflare/solarflare.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local lib      = require("core.lib")

--- a/src/apps/tap/tap.lua
+++ b/src/apps/tap/tap.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local S = require("syscall")

--- a/src/apps/test/synth.lua
+++ b/src/apps/test/synth.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local ffi = require("ffi")

--- a/src/apps/vhost/vhost.h
+++ b/src/apps/vhost/vhost.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 // vhost_memory structure is used to declare which memory address
 // ranges we want to use for DMA. The kernel uses this to create a
 // shared memory mapping.

--- a/src/apps/vhost/vhost_user.c
+++ b/src/apps/vhost/vhost_user.c
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/src/apps/vhost/vhost_user.h
+++ b/src/apps/vhost/vhost_user.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 enum {
     VHOST_USER_MEMORY_MAX_NREGIONS = 8
 };

--- a/src/apps/vhost/vhost_user.lua
+++ b/src/apps/vhost/vhost_user.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 --
 -- See http://www.virtualopensystems.com/en/solutions/guides/snabbswitch-qemu/
 

--- a/src/apps/virtio_net/virtio_net.lua
+++ b/src/apps/virtio_net/virtio_net.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Application to connect to a virtio-net driver implementation
 --
 -- Licensed under the Apache 2.0 license

--- a/src/apps/vpn/vpws.lua
+++ b/src/apps/vpn/vpws.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Virtual Private Wire Service (VPWS)
 -- Provides a L2 VPN on top of IP (v4/v6) and GRE
 --

--- a/src/arch/avx2.c
+++ b/src/arch/avx2.c
@@ -1,8 +1,8 @@
-/* IP checksum routine for AVX2.
- *
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING.
  * Based on original SSE2 code by Tony Rogvall that is
- * copyright 2011 Teclo Networks AG. MIT licensed by Juho Snellman.
- */
+ * copyright 2011 Teclo Networks AG. MIT licensed by Juho Snellman. */
+
+/* IP checksum routine for AVX2. */
 
 #include <stdint.h>
 #include <arpa/inet.h>

--- a/src/arch/sse2.c
+++ b/src/arch/sse2.c
@@ -1,8 +1,8 @@
-/* IP checksum routine for AVX2.
- *
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING.
  * Original code by Tony Rogvall that is
- * copyright 2011 Teclo Networks AG. MIT licensed by Juho Snellman.
- */
+ * copyright 2011 Teclo Networks AG. MIT licensed by Juho Snellman. */
+
+/* IP checksum routine for SSE2. */
 
 #include <stdint.h>
 #include <arpa/inet.h>

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local packet  = require("core.packet")

--- a/src/core/clib.h
+++ b/src/core/clib.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 // sleep(3) - suspend execution for second intervals
 unsigned int sleep(unsigned int seconds);
 

--- a/src/core/config.lua
+++ b/src/core/config.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- 'config' is a data structure that describes an app network.
 
 module(..., package.seeall)

--- a/src/core/counter.h
+++ b/src/core/counter.h
@@ -1,1 +1,3 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 struct counter { uint64_t c; };

--- a/src/core/counter.lua
+++ b/src/core/counter.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- counter.lua - Count discrete events for diagnostic purposes
 -- 
 -- This module provides a thin layer for representing 64-bit counters

--- a/src/core/freelist.lua
+++ b/src/core/freelist.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local ffi = require("ffi")

--- a/src/core/lib.c
+++ b/src/core/lib.c
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 #include <stdint.h>
 #include <time.h>
 #include <sys/stat.h>

--- a/src/core/lib.h
+++ b/src/core/lib.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 uint64_t get_time_ns();
 double get_monotonic_time();
 double get_unix_time();

--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local ffi = require("ffi")

--- a/src/core/link.h
+++ b/src/core/link.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 enum { LINK_RING_SIZE    = 256,
        LINK_MAX_PACKETS  = LINK_RING_SIZE - 1
 };

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local debug = _G.developer_debug

--- a/src/core/main.lua
+++ b/src/core/main.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 -- Default to not using any Lua code on the filesystem.

--- a/src/core/memory.c
+++ b/src/core/memory.c
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 // memory.c -- allocate dma-friendly memory
 //
 // Allocate HugeTLB memory pages for DMA. HugeTLB memory is always

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 int      lock_memory();
 void    *allocate_huge_page(int size);
 uint64_t phys_page(uint64_t virt_page);

--- a/src/core/memory.lua
+++ b/src/core/memory.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 -- For more information about huge pages checkout:

--- a/src/core/packet.h
+++ b/src/core/packet.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 // The maximum amount of payload in any given packet.
 enum { PACKET_PAYLOAD_SIZE = 10*1024 };
 

--- a/src/core/packet.lua
+++ b/src/core/packet.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local debug = _G.developer_debug

--- a/src/core/selftest.lua
+++ b/src/core/selftest.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 require("core.memory").selftest()

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- shm.lua -- shared memory alternative to ffi.new()
 
 -- API:

--- a/src/core/snabbswitch.c
+++ b/src/core/snabbswitch.c
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 #include <stdio.h>
 
 #include "lua.h"

--- a/src/core/startup.lua
+++ b/src/core/startup.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 local ok, err = pcall(require, "core.main")
 if not ok then
    print("startup: unhandled exception")

--- a/src/core/timer.lua
+++ b/src/core/timer.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local ffi = require("ffi")

--- a/src/lib/bloom_filter.lua
+++ b/src/lib/bloom_filter.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- This module implements a basic Bloom filter as described in
 -- <http://en.wikipedia.org/wiki/Bloom_filter>.
 --

--- a/src/lib/checksum.c
+++ b/src/lib/checksum.c
@@ -1,10 +1,10 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING.
+ * Generic checksm routine originally taken from DPDK: 
+ *   BSD license; (C) Intel 2010-2015, 6WIND 2014. */
+
 /* IP checksum routines.
  *
- * See src/arch/ for architecture specific SIMD versions.
- *
- * Generic checksm routine taken from DPDK: 
- *   BSD license; (C) Intel 2010-2015, 6WIND 2014.
- */
+ * See src/arch/ for architecture specific SIMD versions. */
 
 #include <arpa/inet.h>
 #include <stdio.h>

--- a/src/lib/checksum.h
+++ b/src/lib/checksum.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 // Calculate IP checksum using SSE2 instructions.
 // (This will crash if you call it on a CPU that does not support SSE.)
 uint16_t cksum_sse2(unsigned char *p, size_t n, uint16_t initial);

--- a/src/lib/checksum.lua
+++ b/src/lib/checksum.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 -- This module exposes the interface:

--- a/src/lib/checksum_lib.h
+++ b/src/lib/checksum_lib.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 /*
  * Checksum library routines that are inline functions.
  * For inclusion by checksum implementations.

--- a/src/lib/hardware/pci.c
+++ b/src/lib/hardware/pci.c
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 #include <assert.h>
 #include <fcntl.h>
 #include <stdbool.h>

--- a/src/lib/hardware/pci.h
+++ b/src/lib/hardware/pci.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 int open_pci_resource(const char *path);
 void close_pci_resource(int fd, uint32_t *addr);
 uint32_t *map_pci_resource(int fd);

--- a/src/lib/hardware/pci.lua
+++ b/src/lib/hardware/pci.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local ffi = require("ffi")

--- a/src/lib/hardware/register.lua
+++ b/src/lib/hardware/register.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- register.lua -- Hardware device register abstraction
 
 module(...,package.seeall)

--- a/src/lib/hash/base.lua
+++ b/src/lib/hash/base.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Abstract base class for hash functions.
 --
 -- A subclass must define the instance variable "_size" as the number

--- a/src/lib/hash/murmur.lua
+++ b/src/lib/hash/murmur.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Implementation of the MurmurHash3 hash function according to the
 -- reference implementation
 -- https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp

--- a/src/lib/index_set.lua
+++ b/src/lib/index_set.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 --- index set object: keeps a set of indexed values
 local NDX_mt = {}
 NDX_mt.__index = NDX_mt

--- a/src/lib/ipc/shmem/mib.lua
+++ b/src/lib/ipc/shmem/mib.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Subclass of ipc.shmem.shmem that handles data types from the SMIv2
 -- specification.
 --

--- a/src/lib/ipc/shmem/shmem.c
+++ b/src/lib/ipc/shmem/shmem.c
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 #include <sys/mman.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/src/lib/ipc/shmem/shmem.h
+++ b/src/lib/ipc/shmem/shmem.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 char *shmem_grow(void *, void *, size_t, size_t);
 char *shmem_attach(void *, size_t);
 bool shmem_unmap(void *, size_t);

--- a/src/lib/ipc/shmem/shmem.lua
+++ b/src/lib/ipc/shmem/shmem.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- The shmem base class provides a simple IPC mechanism to exchange
 -- arbitrary cdata objects with other processes through a file-backed
 -- shared memeory region, referred to as the "data file".  The memory

--- a/src/lib/lua/class.lua
+++ b/src/lib/lua/class.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Support for basic OO programming.  Apart from the usual
 -- incantations of setmetatable(), it implements a simple mechanism to
 -- avoid table allocations by recycling objects that have been

--- a/src/lib/pcap/filter.h
+++ b/src/lib/pcap/filter.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 struct bpf_program {
   uint32_t bf_len;
   void *bf_insns;

--- a/src/lib/pcap/filter.lua
+++ b/src/lib/pcap/filter.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local pf = require("pf")

--- a/src/lib/pcap/pcap.lua
+++ b/src/lib/pcap/pcap.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local ffi = require("ffi")

--- a/src/lib/pmu.lua
+++ b/src/lib/pmu.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- pmu.lua: Lua interface to the CPU Performance Monitoring Unit
 module(..., package.seeall)
 

--- a/src/lib/pmu_cpu.lua
+++ b/src/lib/pmu_cpu.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- AUTOMATICALLY GENERATED FILE
 -- Date: Fri Aug 14 14:34:23 CEST 2015
 -- Cmd:  scripts/generate-pmu.sh 

--- a/src/lib/protocol/datagram.lua
+++ b/src/lib/protocol/datagram.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- This class provides basic mechanisms for parsing, building and
 -- manipulating a hierarchy of protocol headers and associated payload
 -- contained in a data packet.  In particular, it supports

--- a/src/lib/protocol/ethernet.lua
+++ b/src/lib/protocol/ethernet.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C

--- a/src/lib/protocol/gre.lua
+++ b/src/lib/protocol/gre.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C

--- a/src/lib/protocol/header.lua
+++ b/src/lib/protocol/header.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Protocol header base class
 --
 -- This is an abstract class (should not be instantiated)

--- a/src/lib/protocol/icmp/header.lua
+++ b/src/lib/protocol/icmp/header.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C

--- a/src/lib/protocol/icmp/nd/header.lua
+++ b/src/lib/protocol/icmp/nd/header.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 local proto_header = require("lib.protocol.header")

--- a/src/lib/protocol/icmp/nd/na.lua
+++ b/src/lib/protocol/icmp/nd/na.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C

--- a/src/lib/protocol/icmp/nd/ns.lua
+++ b/src/lib/protocol/icmp/nd/ns.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C

--- a/src/lib/protocol/icmp/nd/options/lladdr.lua
+++ b/src/lib/protocol/icmp/nd/options/lladdr.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 

--- a/src/lib/protocol/icmp/nd/options/tlv.lua
+++ b/src/lib/protocol/icmp/nd/options/tlv.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 

--- a/src/lib/protocol/ipv4.lua
+++ b/src/lib/protocol/ipv4.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C

--- a/src/lib/protocol/ipv6.lua
+++ b/src/lib/protocol/ipv6.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C

--- a/src/lib/protocol/keyed_ipv6_tunnel.lua
+++ b/src/lib/protocol/keyed_ipv6_tunnel.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- This is an implementation of the "Keyed IPv6 Tunnel" specification
 -- conforming to
 -- http://tools.ietf.org/html/draft-mkonstan-keyed-ipv6-tunnel-01.  It

--- a/src/lib/protocol/tcp.lua
+++ b/src/lib/protocol/tcp.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C

--- a/src/lib/protocol/udp.lua
+++ b/src/lib/protocol/udp.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 local ffi = require("ffi")
 local C = ffi.C

--- a/src/lib/traceprof/traceprof.c
+++ b/src/lib/traceprof/traceprof.c
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 // Location where the next instruction pointer value will be stored.
 
 #define _GNU_SOURCE 1

--- a/src/lib/traceprof/traceprof.h
+++ b/src/lib/traceprof/traceprof.h
@@ -1,2 +1,4 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 void traceprof_start(uint64_t *logptr, int maxsamples, int usecs);
 int  traceprof_stop();

--- a/src/lib/traceprof/traceprof.lua
+++ b/src/lib/traceprof/traceprof.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- traceprof.lua: Low-level trace profiler
 -- 
 -- Traceprof analyzes the time spent in JIT-compiled traces.  It is an

--- a/src/lib/virtio/net_device.lua
+++ b/src/lib/virtio/net_device.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Implements virtio-net device
 
 

--- a/src/lib/virtio/net_driver.lua
+++ b/src/lib/virtio/net_driver.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Application to connect to a virtio-net driver implementation
 --
 -- Licensed under the Apache 2.0 license

--- a/src/lib/virtio/virtio.h
+++ b/src/lib/virtio/virtio.h
@@ -1,7 +1,6 @@
-/* virtio.h - Virtual I/O device support in Linux/KVM style
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- */
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
+/* virtio.h - Virtual I/O device support in Linux/KVM style */
 
 enum { VIO_VRING_SIZE = 512 };
 

--- a/src/lib/virtio/virtio_pci.lua
+++ b/src/lib/virtio/virtio_pci.lua
@@ -1,7 +1,6 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Application to connect to a virtio-net driver implementation
---
--- Licensed under the Apache 2.0 license
--- http://www.apache.org/licenses/LICENSE-2.0
 --
 -- Copyright (c) 2015 Virtual Open Systems
 --

--- a/src/lib/virtio/virtio_vring.h
+++ b/src/lib/virtio/virtio_vring.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 // Size of vring structures used in Linux vhost. Max 32768.
 enum { VHOST_VRING_SIZE = 32*1024 };
 

--- a/src/lib/virtio/virtq_device.lua
+++ b/src/lib/virtio/virtq_device.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Implements virtio virtq
 
 

--- a/src/lib/virtio/virtq_driver.lua
+++ b/src/lib/virtio/virtq_driver.lua
@@ -1,7 +1,6 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- Application to connect to a virtio-net driver implementation
---
--- Licensed under the Apache 2.0 license
--- http://www.apache.org/licenses/LICENSE-2.0
 --
 -- Copyright (c) 2015 Virtual Open Systems
 --

--- a/src/lib/watchdog/watchdog.lua
+++ b/src/lib/watchdog/watchdog.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 ffi = require("ffi")

--- a/src/program/example_replay/example_replay.lua
+++ b/src/program/example_replay/example_replay.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local pcap = require("apps.pcap.pcap")

--- a/src/program/example_spray/example_spray.lua
+++ b/src/program/example_spray/example_spray.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local pcap = require("apps.pcap.pcap")

--- a/src/program/example_spray/sprayer.lua
+++ b/src/program/example_spray/sprayer.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 Sprayer = {}

--- a/src/program/firehose/firehose.h
+++ b/src/program/firehose/firehose.h
@@ -1,3 +1,5 @@
+/* Use of this source code is governed by the Apache 2.0 license; see COPYING. */
+
 #include <stdint.h>
 
 /* Called once before processing packets. */

--- a/src/program/firehose/firehose.lua
+++ b/src/program/firehose/firehose.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local lib = require("core.lib")

--- a/src/program/gc/gc.lua
+++ b/src/program/gc/gc.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local lib = require("core.lib")

--- a/src/program/packetblaster/packetblaster.lua
+++ b/src/program/packetblaster/packetblaster.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local engine    = require("core.app")

--- a/src/program/snabbmark/snabbmark.lua
+++ b/src/program/snabbmark/snabbmark.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local usage = require("program.snabbmark.README_inc")

--- a/src/program/snabbnfv/fuzz/fuzz.lua
+++ b/src/program/snabbnfv/fuzz/fuzz.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local lib  = require("core.lib")

--- a/src/program/snabbnfv/neutron2snabb/neutron2snabb.lua
+++ b/src/program/snabbnfv/neutron2snabb/neutron2snabb.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local lib  = require("core.lib")

--- a/src/program/snabbnfv/neutron2snabb/neutron2snabb_schema.lua
+++ b/src/program/snabbnfv/neutron2snabb/neutron2snabb_schema.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 -- neutron2snabb_schema: Scan mysqldump SQL files for schema informaion
 module(..., package.seeall)
 

--- a/src/program/snabbnfv/neutron_sync_agent/neutron_sync_agent.lua
+++ b/src/program/snabbnfv/neutron_sync_agent/neutron_sync_agent.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local lib  = require("core.lib")

--- a/src/program/snabbnfv/neutron_sync_master/neutron_sync_master.lua
+++ b/src/program/snabbnfv/neutron_sync_master/neutron_sync_master.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local lib  = require("core.lib")

--- a/src/program/snabbnfv/nfvconfig.lua
+++ b/src/program/snabbnfv/nfvconfig.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(...,package.seeall)
 
 local VhostUser = require("apps.vhost.vhost_user").VhostUser

--- a/src/program/snabbnfv/snabbnfv.lua
+++ b/src/program/snabbnfv/snabbnfv.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local ffi = require("ffi")

--- a/src/program/snabbnfv/traffic/traffic.lua
+++ b/src/program/snabbnfv/traffic/traffic.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local lib = require("core.lib")

--- a/src/program/snsh/snsh.lua
+++ b/src/program/snsh/snsh.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local lib = require("core.lib")

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -1,3 +1,5 @@
+-- Use of this source code is governed by the Apache 2.0 license; see COPYING.
+
 module(..., package.seeall)
 
 local ffi = require("ffi")


### PR DESCRIPTION
This change adds one-line explicit license references for source files that are Apache 2.0 licensed i.e. the vast majority of code in Snabb Switch:

```
Use of this source code is governed by the Apache 2.0 license; see COPYING.
```

This change attempts to preserve all existing license and copyright messages, with the exception of avoiding redundantly referencing Apache 2.0 license more than once in the same file.

The motivation for this change is twofold:

- To make the source code license more obvious to users and contributors.
- To put into practice the agreement made in issue #729.

The change was initially made automatically with a 'sed' script and then I reviewed each file individually.

Notes:
- avx2.c and sse2.c state that they are derived from MIT-licensed code.
- dynasm lua-mode is already clearly marked as public domain.
- checksum.c states that it is derived from BSD licensed code.
- utilities imported into the project are left as-is e.g. StackTracePlus.lua.

I would appreciate if the upstream reviewer would pass through and sanity check this with fresh eyes!