### PR TITLE
lib.equal can compare cdata

### DIFF
--- a/src/core/lib.lua
+++ b/src/core/lib.lua
@@ -20,6 +20,10 @@ function equal (x, y)
          if x[k] == nil then return false end
       end
       return true
+   elseif type(x) == 'cdata' then
+      local size = ffi.sizeof(x)
+      if ffi.sizeof(y) ~= size then return false end
+      return C.memcmp(x, y, size) == 0
    else
       return x == y
    end


### PR DESCRIPTION
Cdata values are equal if they have the same size and their bytes are
the same.