### PR TITLE
Add "dist" target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,17 @@ clean:
 	(cd lib/luajit && $(MAKE) clean)
 	(cd src; $(MAKE) clean; rm -rf syscall.lua syscall)
 
+PACKAGE:=snabbswitch
+DIST_BINARY:=snabb
+BUILDDIR:=$(shell pwd)
+
+dist: DISTDIR:=$(BUILDDIR)/$(PACKAGE)-$(shell git describe --tags)
+dist: all
+	mkdir "$(DISTDIR)"
+	git clone "$(BUILDDIR)" "$(DISTDIR)/snabbswitch"
+	rm -rf "$(DISTDIR)/snabbswitch/.git"
+	cp "$(BUILDDIR)/src/snabb" "$(DISTDIR)/$(DIST_BINARY)"
+	cd "$(DISTDIR)/.." && tar cJvf "`basename '$(DISTDIR)'`.tar.xz" "`basename '$(DISTDIR)'`"
+	rm -rf "$(DISTDIR)"
+
 .SERIAL: all


### PR DESCRIPTION
Run as "make dist" to generate snabbswitch-`git describe`.tar.xz, which
will contain source code and a built binary.

Set DIST_BINARY to rename the binary.  Set PACKAGE to rename the
package.