### PR TITLE
Exit from VirtioNet:pull if link is nil

### DIFF
--- a/src/apps/virtio_net/virtio_net.lua
+++ b/src/apps/virtio_net/virtio_net.lua
@@ -48,6 +48,7 @@ end
 function VirtioNet:pull()
    local dev = self.device
    local l = self.output.tx
+   if not l then return end
    local to_receive = math.min(nwritable(l), dev:can_receive())
 
    for i=0, to_receive - 1 do


### PR DESCRIPTION
Consider the following script that forwards packets from one nic to another one. NICs use VirtioNet driver (Snabb Switch running within a guest):

```lua
module(..., package.seeall)

local VirtioNet = require("apps.virtio_net.virtio_net").VirtioNet
function run(args)
   local pci1, pci2 = unpack(args)
   local c = config.new()
   config.app(c, "eth0", VirtioNet, {
      pciaddr=pci1,
   })
   config.app(c, "eth1", VirtioNet, {
      pciaddr=pci2,
   })
   config.link(c, "eth0.tx -> eth1.rx")
   engine.configure(c)
   engine.main()
```

The program breaks due to an error in `core/link.lua`:

```lua
core/link.lua:80: attempt to index local 'r' (a nil value)
stack traceback:
        core/main.lua:126: in function '__index'
        core/link.lua:80: in function 'nreadable'
        core/link.lua:88: in function 'nwritable'
```

The problem is that although there's only one link configured, the engine executes `VirtioNet:pull` in `eth1`, and the output link is nil, so a checking that exits `pull` in that case should be added.  I noticed the same checking is present in `intel_app.lua`, and there's a another one for the `push` case. I couldn't reproduce a similar test for `push`, so I didn't add it.

In my opinion, a `pull` in eth1 should never be executed as it's not present on the left side of a link, but maybe I'm missing other reasons while it's being called.