### PR TITLE
Add leaky=false mode to RateLimiter.

### DIFF
--- a/src/apps/rate_limiter/README.md
+++ b/src/apps/rate_limiter/README.md
@@ -7,7 +7,7 @@ the `input` port and transmits conforming packets to the `output` port.
 
 ![RateLimiter](.images/RateLimiter.png)
 
-— Method **RateLimiter:snapshot**
+— Method **RateLimiter:get_stat_snapshot**
 
 Returns throughput statistics in form of a table with the following
 fields:
@@ -15,6 +15,11 @@ fields:
 * `rx` - Number of packets received
 * `tx` - Number of packets transmitted
 * `time` - Current time in nanoseconds
+
+— Method **RateLimiter:set_rate** byte_rate
+
+Configure the rate limiter to refill its empty its bucket at the new
+rate of `byte_rate` bytes per second.
 
 
 ## Configuration
@@ -26,6 +31,14 @@ following keys are defined:
 
 *Required*. Rate in bytes per second to which throughput should be
 limited.
+
+— Key **leaky**
+
+*Optional*.  If true, any incoming traffic that is beyond the configured
+throughput will be dropped.  Otherwise, incoming traffic beyond the
+configured threshold is left on the input link and will be dequeued when
+enough time has passed that the throughput will not be exceeded.
+Defaults to false.
 
 — Key **bucket_capacity**
 

--- a/src/apps/rate_limiter/README.md
+++ b/src/apps/rate_limiter/README.md
@@ -18,8 +18,8 @@ fields:
 
 — Method **RateLimiter:set_rate** byte_rate
 
-Configure the rate limiter to refill its empty its bucket at the new
-rate of `byte_rate` bytes per second.
+Configure the rate limiter to limit throughput to `byte_rate` bytes
+per second.
 
 
 ## Configuration

--- a/src/apps/rate_limiter/rate_limiter.lua
+++ b/src/apps/rate_limiter/rate_limiter.lua
@@ -25,8 +25,10 @@ local PACKET_SIZE = 60
 
 function RateLimiter:new (arg)
    local conf = arg and config.parse_app_arg(arg) or {}
-   assert(conf.rate)
-   assert(conf.bucket_capacity)
+   --- By default, limit to 10 Mbps, just to have a default.
+   conf.rate = conf.rate or (10e6 / 8)
+   -- By default, allow for 255 standard packets in the queue.
+   conf.bucket_capacity = conf.bucket_capacity or (255 * 1500)
    conf.initial_capacity = conf.initial_capacity or conf.bucket_capacity
    local o =
    {

--- a/src/program/snabbnfv/nfvconfig.lua
+++ b/src/program/snabbnfv/nfvconfig.lua
@@ -48,7 +48,8 @@ function load (file, pciaddr, sockpath)
       if t.tx_police_gbps then
          local TxLimit = name.."_TxLimit"
          local rate = t.tx_police_gbps * 1e9 / 8
-         config.app(c, TxLimit, RateLimiter, {rate = rate, bucket_capacity = rate})
+         config.app(c, TxLimit, RateLimiter,
+                    {rate = rate, bucket_capacity = rate, leaky = true})
          config.link(c, VM_tx.." -> "..TxLimit..".input")
          VM_tx = TxLimit..".output"
       end
@@ -95,7 +96,8 @@ function load (file, pciaddr, sockpath)
       if t.rx_police_gbps then
          local RxLimit = name.."_RxLimit"
          local rate = t.rx_police_gbps * 1e9 / 8
-         config.app(c, RxLimit, RateLimiter, {rate = rate, bucket_capacity = rate})
+         config.app(c, RxLimit, RateLimiter,
+                    {rate = rate, bucket_capacity = rate, leaky = true})
          config.link(c, RxLimit..".output -> "..VM_rx)
          VM_rx = RxLimit..".input"
       end


### PR DESCRIPTION
This adds a configuration argument to RateLimiter, leaky.  If it's true, you have the previous mode of operation where incoming traffic that's above the threshold is dropped.  Otherwise it is left on the incoming ring buffer.

As a functional change, this new parameter defaults to false, meaning that users of RateLimiter should update their configurations.

Also, RateLimiter now provides default values for rate and bucket_capacity.

I have tested this code in the lwaftr test harness (https://github.com/Igalia/snabbswitch/pull/281), and it seems to work correctly.  I have not tested the change to the NFV.  @eugeneia would you mind having a look?  Thanks in advance :)  (This is a follow-on to #782.)