### PR TITLE
Replace shm.map with separate create() and open()

### DIFF
--- a/src/core/counter.lua
+++ b/src/core/counter.lua
@@ -46,13 +46,14 @@ local numbers = {} -- name -> number
 function open (name, readonly)
    if numbers[name] then error("counter already opened: " .. name) end
    local n = #public+1
-   numbers[name] = n
-   public[n] = shm.map(name, counter_t, readonly)
    if readonly then
+      public[n] = shm.open(name, counter_t, readonly)
       private[n] = public[#public] -- use counter directly
    else
+      public[n] = shm.create(name, counter_t)
       private[n] = ffi.new(counter_t)
    end
+   numbers[name] = n
    return private[n]
 end
 
@@ -86,7 +87,7 @@ function selftest ()
    print("selftest: core.counter")
    local a  = open("core.counter/counter/a")
    local b  = open("core.counter/counter/b")
-   local a2 = shm.map("core.counter/counter/a", counter_t, true)
+   local a2 = shm.create("core.counter/counter/a", counter_t, true)
    set(a, 42)
    set(b, 43)
    assert(read(a) == 42)

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -24,7 +24,7 @@ max        = C.LINK_MAX_PACKETS
 local counternames = {"rxpackets", "txpackets", "rxbytes", "txbytes", "txdrop"}
 
 function new (name)
-   local r = shm.map("links/"..name, "struct link")
+   local r = shm.create("links/"..name, "struct link")
    for _, c in ipairs(counternames) do
       r.stats[c] = counter.open("counters/"..name.."/"..c)
    end

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -92,7 +92,7 @@ local function map (name, type, readonly, create)
       mkdir(path)
       fd, err = S.open(root..'/'..path, "creat, rdwr", "rwxu")
    else
-      fd, err = S.open(root..'/'..path, "rdonly")
+      fd, err = S.open(root..'/'..path, readonly and "rdonly" or "rdwr")
    end
    if not fd then error("shm open error ("..path.."):"..tostring(err)) end
    if create then

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -95,7 +95,11 @@ local function map (name, type, readonly, create)
       fd, err = S.open(root..'/'..path, "rdonly")
    end
    if not fd then error("shm open error ("..path.."):"..tostring(err)) end
-   assert(fd:ftruncate(size), "shm: ftruncate failed")
+   if create then
+      assert(fd:ftruncate(size), "shm: ftruncate failed")
+   else
+      assert(fd:fstat().size == size, "shm: unexpected size")
+   end
    local mem, err = S.mmap(nil, size, mapmode, "shared", fd, 0)
    fd:close()
    if mem == nil then error("mmap failed: " .. tostring(err)) end

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -4,10 +4,10 @@
 
 -- API:
 --   shm.create(name, type) => ptr
---     Map a shared object into memory via a heirarchical name, creating it
+--     Map a shared object into memory via a hierarchical name, creating it
 --     if needed.
 --   shm.open(name, type[, readonly]) => ptr
---     Map a shared object into memory via a heirarchical name.  Fail if
+--     Map a shared object into memory via a hierarchical name.  Fail if
 --     the shared object does not already exist.
 --   shm.unmap(ptr)
 --     Delete a memory mapping.


### PR DESCRIPTION
Currently shm.map() will create the file and any containing directories
if it does not exist.  This is not so great, so I split it into separate
open() and create() functions, adapt all callers, and remove map() from
the public interface of the shm module.