### PR TITLE
Add core.histogram, use it to measure latency of app.breathe()

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -198,6 +198,11 @@ following keys are recognized:
    set to boolean values to force or suppress link and app reporting
    individually. By default `engine.main()' will report on links but not
    on apps.
+ * `measure_latency` - By default, the `breathe()` loop is instrumented
+   to record the latency distribution of running the app graph.  This
+   information can be processed by the `snabb top` program.  Passing
+   `measure_latency=false` in the *options* will disable this
+   instrumentation.
  * `no_report` - A boolean value. If `true` no final report will be
    printed.
 

--- a/src/core/app.lua
+++ b/src/core/app.lua
@@ -2,15 +2,16 @@
 
 module(...,package.seeall)
 
-local packet  = require("core.packet")
-local lib     = require("core.lib")
-local link    = require("core.link")
-local config  = require("core.config")
-local timer   = require("core.timer")
-local counter = require("core.counter")
-local zone    = require("jit.zone")
-local ffi     = require("ffi")
-local C       = ffi.C
+local packet    = require("core.packet")
+local lib       = require("core.lib")
+local link      = require("core.link")
+local config    = require("core.config")
+local timer     = require("core.timer")
+local histogram = require('core.histogram')
+local counter   = require("core.counter")
+local zone      = require("jit.zone")
+local ffi       = require("ffi")
+local C         = ffi.C
 require("core.packet_h")
 
 -- Set to true to enable logging
@@ -238,6 +239,13 @@ function main (options)
       assert(not done, "You can not have both 'duration' and 'done'")
       done = lib.timer(options.duration * 1e9)
    end
+
+   local breathe = breathe
+   if options.measure_latency or options.measure_latency == nil then
+      local latency = histogram.create('engine/latency', 1e-6, 1e0)
+      breathe = latency:wrap_thunk(breathe, now)
+   end
+
    monotonic_now = C.get_monotonic_time()
    repeat
       breathe()

--- a/src/core/counter.lua
+++ b/src/core/counter.lua
@@ -46,13 +46,14 @@ local numbers = {} -- name -> number
 function open (name, readonly)
    if numbers[name] then error("counter already opened: " .. name) end
    local n = #public+1
-   numbers[name] = n
-   public[n] = shm.map(name, counter_t, readonly)
    if readonly then
+      public[n] = shm.open(name, counter_t, readonly)
       private[n] = public[#public] -- use counter directly
    else
+      public[n] = shm.create(name, counter_t)
       private[n] = ffi.new(counter_t)
    end
+   numbers[name] = n
    return private[n]
 end
 
@@ -86,7 +87,7 @@ function selftest ()
    print("selftest: core.counter")
    local a  = open("core.counter/counter/a")
    local b  = open("core.counter/counter/b")
-   local a2 = shm.map("core.counter/counter/a", counter_t, true)
+   local a2 = shm.create("core.counter/counter/a", counter_t, true)
    set(a, 42)
    set(b, 43)
    assert(read(a) == 42)

--- a/src/core/histogram.lua
+++ b/src/core/histogram.lua
@@ -52,7 +52,7 @@ local log, floor, max, min = math.log, math.floor, math.max, math.min
 local histogram_t = ffi.typeof([[struct {
    double minimum;
    double growth_factor_log;
-   uint64_t count;
+   uint64_t total;
    uint64_t buckets[509];
 }]])
 
@@ -91,7 +91,7 @@ function add(histogram, measurement)
       bucket = max(0, bucket)
       bucket = min(508, bucket)
    end
-   histogram.count = histogram.count + 1
+   histogram.total = histogram.total + 1
    histogram.buckets[bucket] = histogram.buckets[bucket] + 1
 end
 
@@ -123,7 +123,7 @@ function snapshot(a, b)
 end
 
 function clear(histogram)
-   histogram.count = 0
+   histogram.total = 0
    for bucket = 0, 508 do histogram.buckets[bucket] = 0 end
 end
 
@@ -158,8 +158,8 @@ function selftest ()
    h:add(1.5)
    assert(h.buckets[508] == 1)
 
-   assert(h.count == 4)
-   assert(h:snapshot().count == 4)
+   assert(h.total == 4)
+   assert(h:snapshot().total == 4)
    assert(h:snapshot().buckets[508] == 1)
 
    local total = 0
@@ -181,7 +181,7 @@ function selftest ()
    assert(total == 4)
 
    h:clear()
-   assert(h.count == 0)
+   assert(h.total == 0)
    assert(h.buckets[508] == 0)
 
    print("selftest ok")

--- a/src/core/histogram.lua
+++ b/src/core/histogram.lua
@@ -16,9 +16,18 @@
 --   histogram.add(histogram, measurement)
 --     Add a measurement to a histogram.
 --
---   histogram.report(histogram, prev)
---     Print out non-empty buckets and their ranges.  If PREV is given,
---     it should be a snapshot of the previous version of the histogram.
+--   histogram.iterate(histogram, prev)
+--     When used as "for bucket, lo, hi, count in histogram:iterate()",
+--     visits all buckets in a histogram.  BUCKET is the bucket index,
+--     starting from zero, LO and HI are the lower and upper bounds of
+--     the bucket, and COUNT is the number of samples recorded in that
+--     bucket.  Note that COUNT is an unsigned 64-bit integer; to get it
+--     as a Lua number, use tonumber().
+--
+--     If PREV is given, it should be a snapshot of the previous version
+--     of the histogram.  In that case, the COUNT values will be
+--     returned as a diffference between their values in HISTOGRAM and
+--     their values in PREV.
 --
 --   histogram.snapshot(a, b)
 --     Copy out the contents of A into B and return B.  If B is not given,

--- a/src/core/histogram.lua
+++ b/src/core/histogram.lua
@@ -1,0 +1,181 @@
+-- histogram.lua -- a histogram with logarithmic buckets
+--
+-- API:
+--   histogram.new(min, max) => histogram
+--     Make a new histogram, with buckets covering the range from MIN to MAX.
+--     The range between MIN and MAX will be divided logarithmically.
+--
+--   histogram.create(name, min, max) => histogram
+--     Create a histogram as in new(), but also map it into
+--     /var/run/snabb/PID/NAME, exposing it for analysis by other processes.
+--     If the file exists already, it will be cleared.
+--
+--   histogram.open(pid, name) => histogram
+--     Open a histogram mapped as /var/run/snabb/PID/NAME.
+--
+--   histogram.add(histogram, measurement)
+--     Add a measurement to a histogram.
+--
+--   histogram.report(histogram, prev)
+--     Print out non-empty buckets and their ranges.  If PREV is given,
+--     it should be a snapshot of the previous version of the histogram.
+--
+--   histogram.snapshot(a, b)
+--     Copy out the contents of A into B and return B.  If B is not given,
+--     the result will be a fresh histogram.
+--
+--   histogram.clear(a)
+--     Clear the counters in A.
+--
+--   histogram.wrap_thunk(histogram, thunk, now)
+--     Return a closure that wraps THUNK, but which measures the difference
+--     between calls to NOW before and after the thunk, recording that
+--     difference into HISTOGRAM.
+--
+module(...,package.seeall)
+
+local ffi = require("ffi")
+local shm = require("core.shm")
+local log, floor, max, min = math.log, math.floor, math.max, math.min
+
+-- Fill a 4096-byte page with buckets.  4096/8 = 512, minus the three
+-- header words means 509 buckets.  The first and last buckets are catch-alls.
+local histogram_t = ffi.typeof([[struct {
+   double minimum;
+   double growth_factor_log;
+   uint64_t count;
+   uint64_t buckets[509];
+}]])
+
+local function compute_growth_factor_log(minimum, maximum)
+   assert(minimum > 0)
+   assert(maximum > minimum)
+   -- 507 buckets for precise steps within minimum and maximum, 2 for
+   -- the catch-alls.
+   return log(maximum / minimum) / 507
+end
+
+function new(minimum, maximum)
+   return histogram_t(minimum, compute_growth_factor_log(minimum, maximum))
+end
+
+function create(name, minimum, maximum)
+   local histogram = shm.create(name, histogram_t)
+   histogram.minimum = minimum
+   histogram.growth_factor_log = compute_growth_factor_log(minimum, maximum)
+   histogram:clear()
+   return histogram
+end
+
+function open(name)
+   return shm.open(name, histogram_t)
+end
+
+function add(histogram, measurement)
+   local bucket
+   if measurement <= 0 then
+      bucket = 0
+   else
+      bucket = log(measurement / histogram.minimum)
+      bucket = bucket / histogram.growth_factor_log
+      bucket = floor(bucket) + 1
+      bucket = max(0, bucket)
+      bucket = min(508, bucket)
+   end
+   histogram.count = histogram.count + 1
+   histogram.buckets[bucket] = histogram.buckets[bucket] + 1
+end
+
+function report(histogram, prev)
+   local lo, hi = 0, histogram.minimum
+   local factor = math.exp(histogram.growth_factor_log)
+   local total = histogram.count
+   if prev then total = total - prev.count end
+   total = tonumber(total)
+   for bucket = 0, 508 do
+      local count = histogram.buckets[bucket]
+      if prev then count = count - prev.buckets[bucket] end
+      if count ~= 0 then
+         print(string.format('%.3e - %.3e: %u (%.5f%%)', lo, hi, tonumber(count),
+                             tonumber(count) / total * 100.))
+      end
+      lo, hi = hi, hi * factor
+   end
+end
+
+function summarize(histogram, prev)
+   local lo, hi = 0, histogram.minimum
+   local factor = math.exp(histogram.growth_factor_log)
+   local total = histogram.count
+   if prev then total = total - prev.count end
+   total = tonumber(total)
+   local min, max, cumulative = 1/0, 0, 0
+   for bucket = 0, 508 do
+      local count = histogram.buckets[bucket]
+      if prev then count = count - prev.buckets[bucket] end
+      if count ~= 0 then
+         if lo < min then min = lo end
+         if hi > max then max = hi end
+         cumulative = cumulative + (lo + hi) / 2 * tonumber(count)
+      end
+      lo, hi = hi, hi * factor
+   end
+   return min, cumulative / total, max
+end
+
+function snapshot(a, b)
+   b = b or histogram_t()
+   ffi.copy(b, a, ffi.sizeof(histogram_t))
+   return b
+end
+
+function clear(histogram)
+   histogram.count = 0
+   for bucket = 0, 508 do histogram.buckets[bucket] = 0 end
+end
+
+function wrap_thunk(histogram, thunk, now)
+   return function()
+      local start = now()
+      thunk()
+      histogram:add(now() - start)
+   end
+end
+
+ffi.metatype(histogram_t, {__index = {
+   add = add,
+   report = report,
+   summarize = summarize,
+   snapshot = snapshot,
+   wrap_thunk = wrap_thunk,
+   clear = clear
+}})
+
+function selftest ()
+   print("selftest: histogram")
+
+   local h = new(1e-6, 1e0)
+   assert(ffi.sizeof(h) == 4096)
+
+   h:add(1e-7)
+   assert(h.buckets[0] == 1)
+   h:add(1e-6 + 1e-9)
+   assert(h.buckets[1] == 1)
+   h:add(1.0 - 1e-9)
+   assert(h.buckets[507] == 1)
+   h:add(1.5)
+   assert(h.buckets[508] == 1)
+
+   assert(h.count == 4)
+   assert(h:snapshot().count == 4)
+   assert(h:snapshot().buckets[508] == 1)
+
+   h:report()
+
+   h:clear()
+   assert(h.count == 0)
+   assert(h.buckets[508] == 0)
+
+   print("selftest ok")
+end
+

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -24,7 +24,7 @@ max        = C.LINK_MAX_PACKETS
 local counternames = {"rxpackets", "txpackets", "rxbytes", "txbytes", "txdrop"}
 
 function new (name)
-   local r = shm.map("links/"..name, "struct link")
+   local r = shm.create("links/"..name, "struct link")
    for _, c in ipairs(counternames) do
       r.stats[c] = counter.open("counters/"..name.."/"..c)
    end

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -92,7 +92,7 @@ local function map (name, type, readonly, create)
       mkdir(path)
       fd, err = S.open(root..'/'..path, "creat, rdwr", "rwxu")
    else
-      fd, err = S.open(root..'/'..path, "rdonly")
+      fd, err = S.open(root..'/'..path, readonly and "rdonly" or "rdwr")
    end
    if not fd then error("shm open error ("..path.."):"..tostring(err)) end
    if create then

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -95,7 +95,11 @@ local function map (name, type, readonly, create)
       fd, err = S.open(root..'/'..path, "rdonly")
    end
    if not fd then error("shm open error ("..path.."):"..tostring(err)) end
-   assert(fd:ftruncate(size), "shm: ftruncate failed")
+   if create then
+      assert(fd:ftruncate(size), "shm: ftruncate failed")
+   else
+      assert(fd:fstat().size == size, "shm: unexpected size")
+   end
    local mem, err = S.mmap(nil, size, mapmode, "shared", fd, 0)
    fd:close()
    if mem == nil then error("mmap failed: " .. tostring(err)) end

--- a/src/core/shm.lua
+++ b/src/core/shm.lua
@@ -4,10 +4,10 @@
 
 -- API:
 --   shm.create(name, type) => ptr
---     Map a shared object into memory via a heirarchical name, creating it
+--     Map a shared object into memory via a hierarchical name, creating it
 --     if needed.
 --   shm.open(name, type[, readonly]) => ptr
---     Map a shared object into memory via a heirarchical name.  Fail if
+--     Map a shared object into memory via a hierarchical name.  Fail if
 --     the shared object does not already exist.
 --   shm.unmap(ptr)
 --     Delete a memory mapping.

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -129,7 +129,7 @@ function summarize_latency(histogram, prev)
    if prev then total = total - prev.total end
    if total == 0 then return 0, 0, 0 end
    local min, max, cumulative = nil, 0, 0
-   for bucket, lo, hi, count in histogram:iterate(prev) do
+   for count, lo, hi in histogram:iterate(prev) do
       if count ~= 0 then
 	 if not min then min = lo end
 	 max = hi

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -125,8 +125,8 @@ function print_global_metrics (new_stats, last_stats)
 end
 
 function summarize_latency(histogram, prev)
-   local total = histogram.count
-   if prev then total = total - prev.count end
+   local total = histogram.total
+   if prev then total = total - prev.total end
    if total == 0 then return 0, 0, 0 end
    local min, max, cumulative = nil, 0, 0
    for bucket, lo, hi, count in histogram:iterate(prev) do

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -8,6 +8,7 @@ local lib = require("core.lib")
 local shm = require("core.shm")
 local counter = require("core.counter")
 local S = require("syscall")
+local histogram = require("core.histogram")
 local usage = require("program.top.README_inc")
 
 local long_opts = {
@@ -38,6 +39,7 @@ function run (args)
          clearterm()
          print_global_metrics(new_stats, last_stats)
          io.write("\n")
+         print_latency_metrics(new_stats, last_stats)
          print_link_metrics(new_stats, last_stats)
          io.flush()
       end
@@ -69,6 +71,8 @@ function open_counters (tree)
    for _, name in ipairs({"configs", "breaths", "frees", "freebytes"}) do
       counters[name] = counter.open(tree.."/engine/"..name, 'readonly')
    end
+   local success, latency = pcall(histogram.open, tree..'/engine/latency')
+   if success then counters.latency = latency end
    counters.links = {} -- These will be populated on demand.
    return counters
 end
@@ -98,6 +102,7 @@ function get_stats (counters)
    for _, name in ipairs({"configs", "breaths", "frees", "freebytes"}) do
       new_stats[name] = counter.read(counters[name])
    end
+   if counters.latency then new_stats.latency = counters.latency:snapshot() end
    new_stats.links = {}
    for linkspec, link in pairs(counters.links) do
       new_stats.links[linkspec] = {}
@@ -117,6 +122,18 @@ function print_global_metrics (new_stats, last_stats)
    print_row(global_metrics_row, {"Kfrees/s", "freeGbytes/s", "breaths/s"})
    print_row(global_metrics_row,
              {float_s(frees / 1000), float_s(bytes / (1000^3)), tostring(breaths)})
+end
+
+function print_latency_metrics (new_stats, last_stats)
+   local cur, prev = new_stats.latency, last_stats.latency
+   if not cur then return end
+   local min, avg, max = cur:summarize(prev)
+   print_row(global_metrics_row,
+             {"Min breath (us)", "Average", "Maximum"})
+   
+   print_row(global_metrics_row,
+             {float_s(min*1e6), float_s(avg*1e6), float_s(max*1e6)})
+   print("\n")
 end
 
 local link_metrics_row = {31, 7, 7, 7, 7, 7}

--- a/src/program/top/top.lua
+++ b/src/program/top/top.lua
@@ -124,10 +124,25 @@ function print_global_metrics (new_stats, last_stats)
              {float_s(frees / 1000), float_s(bytes / (1000^3)), tostring(breaths)})
 end
 
+function summarize_latency(histogram, prev)
+   local total = histogram.count
+   if prev then total = total - prev.count end
+   if total == 0 then return 0, 0, 0 end
+   local min, max, cumulative = nil, 0, 0
+   for bucket, lo, hi, count in histogram:iterate(prev) do
+      if count ~= 0 then
+	 if not min then min = lo end
+	 max = hi
+	 cumulative = cumulative + (lo + hi) / 2 * tonumber(count)
+      end
+   end
+   return min, cumulative / tonumber(total), max
+end
+
 function print_latency_metrics (new_stats, last_stats)
    local cur, prev = new_stats.latency, last_stats.latency
    if not cur then return end
-   local min, avg, max = cur:summarize(prev)
+   local min, avg, max = summarize_latency(cur, prev)
    print_row(global_metrics_row,
              {"Min breath (us)", "Average", "Maximum"})
    


### PR DESCRIPTION
This commit adds a histogram facility that can record the distribution
of different sampled magnitudes.  In particular, it is useful for
recording distributions of times.  Histograms can be mapped into
/var/run/snabb, where they can be analyzed by a separate process.

This commit also wires up the app.breathe() loop to record latencies for
its breath cycles into a well-known
file (/var/run/snabb/PID/engine/latency), and wires up "snabb top" to do
some basic statistics on this data.

A follow-on to #777 rebased onto #794.