### PR TITLE
[wip] multi-process ring buffers

### DIFF
--- a/src/core/link.h
+++ b/src/core/link.h
@@ -11,14 +11,10 @@ struct link {
   struct {
     struct counter *txbytes, *rxbytes, *txpackets, *rxpackets, *txdrop;
   } stats;
-  char pad[24];
   // Two cursors:
   //   read:  the next element to be read
   //   write: the next element to be written
-  int read;
-  char read_pad[60];
-  int write;
-  char write_pad[60];
+  int read, write;
   // Index (into the Lua app.active_apps array) of the app that
   // receives from this link.
   int receiving_app;

--- a/src/core/link.h
+++ b/src/core/link.h
@@ -11,10 +11,14 @@ struct link {
   struct {
     struct counter *txbytes, *rxbytes, *txpackets, *rxpackets, *txdrop;
   } stats;
+  char pad[24];
   // Two cursors:
   //   read:  the next element to be read
   //   write: the next element to be written
-  int read, write;
+  int read;
+  char read_pad[60];
+  int write;
+  char write_pad[60];
   // Index (into the Lua app.active_apps array) of the app that
   // receives from this link.
   int receiving_app;

--- a/src/core/link.lua
+++ b/src/core/link.lua
@@ -49,6 +49,27 @@ function receive (r)
    return p
 end
 
+function maybe_rx (r)
+   local p = r.packets[r.read]
+   if p == nil then
+      return nil
+   else
+      r.packets[r.read] = nil
+      r.read = band(r.read + 1, size - 1)
+      return p
+   end
+end
+
+function maybe_tx (r, p)
+   if r.packets[r.write] ~= nil then
+      return nil
+   else
+      r.packets[r.write] = p
+      r.write = band(r.write + 1, size - 1)
+      return p
+   end
+end
+
 function front (r)
    return (r.read ~= r.write) and r.packets[r.read] or nil
 end

--- a/src/program/snabbmark/mp.lua
+++ b/src/program/snabbmark/mp.lua
@@ -9,11 +9,204 @@ local S = require("syscall")
 local pmu = require("lib.pmu")
 local lib = require("core.lib")
 
+local shm = require("core.shm")
+local band = require("bit").band
+
 -- Ring benchmark:
 -- See how quickly packets are cycled through a ring of processes.
 --
 -- Each process copies packets from its input to its output link. Each
 -- link is populated with an initial "burst" of packets.
+
+local cache_line_size = 64
+
+-- ff (FastForward) link
+
+-- John Giacomoni, Tipp Moseley, and Manish Vachharajani. 2008.
+-- FastForward for efficient pipeline parallelism:
+-- a cache-optimized concurrent lock-free queue. In Proceedings of the
+-- 13th ACM SIGPLAN Symposium on Principles and practice of parallel
+-- programming (PPoPP '08). ACM, New York, NY, USA, 43-52.
+-- DOI=http://dx.doi.org/10.1145/1345206.1345215
+
+local ff_size = 256
+
+ffi.cdef([[
+/*
+ * Put read and write members on private cache lines,
+ * which are assumed to be 64 bytes long.
+ */
+struct ff_link
+{
+    struct packet *packets[$];
+    uint32_t read  __attribute__((aligned(64)));
+    uint32_t write __attribute__((aligned(64)));
+};
+]], ff_size)
+
+function ff_new (name)
+   local r = shm.map("links/"..name, "struct ff_link")
+   -- try to verify expected alignment
+   local p = ffi.new("struct ff_link *[1]")
+   p[0] = r
+   local n = ffi.cast("uintptr_t", p[0])
+   local mask = cache_line_size - 1
+   assert(band(n, mask) == 0, "struct ff_link not 64-bit aligned")
+   assert(band(ffi.offsetof("struct ff_link", "read"), mask) == 0,
+	  "read field not 64-bit aligned within struct ff_link")
+   assert(band(ffi.offsetof("struct ff_link", "write"), mask) == 0,
+	  "write field not 64-bit aligned within struct ff_link")
+   return r
+end
+
+function ff_empty (r)
+   return r.packets[r.read] == nil
+end
+
+function ff_available (r)
+   return r.packets[r.write] == nil
+end
+
+function ff_full (r)
+   return r.packets[r.write] ~= nil
+end
+
+function ff_maybe_rx (r)
+   local p = r.packets[r.read];
+   if p ~= nil then
+      r.packets[r.read] = nil;
+      r.read = band(r.read + 1, ff_size - 1)
+   end
+   return p
+end
+
+function ff_maybe_tx (r, p)
+   if r.packets[r.write] ~= nil then
+      return nil
+   else
+      r.packets[r.write] = p
+      r.write = band(r.write + 1, ff_size - 1)
+      return p
+   end
+end
+
+
+-- mc (MCRingBuffer) link
+
+-- Patrick P. C. Lee, Tian Bu, and Girish Chandranmenon. 2009.
+-- A lock-free, cache-efficient shared ring buffer for multi-core architectures.
+-- In Proceedings of the 5th ACM/IEEE Symposium on Architectures for Networking
+-- and Communications Systems (ANCS '09). ACM, New York, NY, USA, 78-79.
+-- DOI=http://dx.doi.org/10.1145/1882486.1882508
+
+local mc_size = 256
+local mc_batch_size = 10
+
+ffi.cdef([[
+struct mc_link
+{
+    struct packet *packets[$];
+    uint32_t read __attribute__((aligned(64)));
+    uint32_t write;
+    uint32_t local_write __attribute__((aligned(64)));
+    uint32_t next_read;
+    uint32_t read_batch;
+    uint32_t local_read __attribute__((aligned(64)));
+    uint32_t next_write;
+    uint32_t write_batch;
+};
+]], mc_size)
+
+function mc_new (name)
+   local r = shm.map("links/"..name, "struct mc_link")
+   local p = ffi.new("struct mc_link *[1]")
+   p[0] = r
+   local n = ffi.cast("uintptr_t", p[0])
+   local mask = cache_line_size - 1
+   assert(band(n, mask) == 0, "struct mc_link not 64-bit aligned")
+   assert(band(ffi.offsetof("struct mc_link", "read"), mask) == 0,
+	  "read field not 64-byte aligned within struct mc_link")
+   assert(band(ffi.offsetof("struct mc_link", "local_write"), mask) == 0,
+	  "local_write field not 64-byte aligned within struct mc_link")
+   assert(band(ffi.offsetof("struct mc_link", "local_read"), mask) == 0,
+	  "local_read field not 64-byte aligned within struct mc_link")
+
+   return r
+end
+
+function mc_maybe_rx (r)
+   if r.next_read == r.local_write then
+      if r.next_read == r.write then
+	 return nil
+      end
+      r.local_write = r.write
+   end
+   local p = r.packets[r.next_read]
+   r.next_read = band(r.next_read + 1, mc_size -1)
+   r.read_batch = r.read_batch + 1
+   if r.read_batch >= mc_batch_size then
+      r.read = r.next_read
+      r.read_batch = 0
+   end
+   return p
+end
+
+function mc_maybe_tx (r, p)
+   local after_next = band(r.next_write + 1, mc_size - 1)
+   if after_next == r.local_read then
+      if after_next == r.read then
+	 return nil
+      end
+      r.local_read = r.read
+   end
+   r.packets[r.next_write] = p
+   r.next_write = after_next
+   r.write_batch = r.write_batch + 1
+   if r.write_batch >= mc_batch_size then
+      r.write = r.next_write
+      r.write_batch = 0
+   end
+   return p
+end
+
+
+function make_links(mode, nlinks, npackets)
+   local links = {}
+
+   if mode == "basic" then
+      for i = 0, nlinks - 1 do
+	 links[i] = link.new(tostring(i))
+	 for j = 1, npackets do
+	    link.transmit(links[i], packet.allocate())
+	 end
+      end
+   elseif mode == "ff" then
+      for i = 0, nlinks - 1 do
+	 links[i] = ff_new(tostring(i))
+	 for j = 1, npackets do
+	    local p = ff_maybe_tx(links[i], packet.allocate())
+	    if p == nil then
+	       error("can't transmit packet while priming ff links")
+	    end
+	 end
+      end
+   elseif mode == "mc" then
+      for i = 0, nlinks - 1 do
+	 links[i] = mc_new(tostring(i))
+	 for j = 1, npackets do
+	    local p = mc_maybe_tx(links[i], packet.allocate())
+	    if p == nil then
+	       error("can't transmit packet while priming mc links")
+	    end
+	 end
+      end
+   else
+      error("unknown mode " .. mode)
+   end
+
+   return links
+end
+
 function mp_ring (args)
    local function usage ()
       print(require("program.snabbmark.README_mp_inc"))
@@ -54,14 +247,16 @@ function mp_ring (args)
    for k, v in pairs(c) do
       print(("%12s: %s"):format(k,v))
    end
-   links = {}
+
+   links = make_links(c.mode, c.processes, c.burst)
+   
    -- Create links to connect the processes in a loop
-   for i = 0, c.processes-1 do
-      links[i] = link.new(tostring(i))
-      for j = 1, c.burst do
-         link.transmit(links[i], packet.allocate())
-      end
-   end
+   -- for i = 0, c.processes-1 do
+   --    links[i] = link.new(tostring(i))
+   --    for j = 1, c.burst do
+   --       link.transmit(links[i], packet.allocate())
+   --    end
+   -- end
    -- Create per-process counters
    local counters = ffi.cast("uint64_t *",
                              memory.dma_alloc(c.processes*ffi.sizeof("uint64_t")))
@@ -106,7 +301,7 @@ function mp_ring (args)
 	 elseif c.mode == "ff" then
             local acc = ffi.new("uint8_t[1]")
 	    while counters[i] < c.packets do
-	       local p = link.maybe_rx(input)
+	       local p = ff_maybe_rx(input)
 	       if p ~= nil then
                   -- Read some packet data
                   for j = 0, c.readbytes do
@@ -119,7 +314,29 @@ function mp_ring (args)
 
 		  local sent = nil
 		  repeat
-		     sent = link.maybe_tx(output, p)
+		     sent = ff_maybe_tx(output, p)
+		  until sent ~= nil
+		  counters[i] = counters[i] + 1
+	       end
+	       core.lib.compiler_barrier()
+	    end
+	 elseif c.mode == "mc" then
+            local acc = ffi.new("uint8_t[1]")
+	    while counters[i] < c.packets do
+	       local p = mc_maybe_rx(input)
+	       if p ~= nil then
+                  -- Read some packet data
+                  for j = 0, c.readbytes do
+                     acc[0] = acc[0] + p.data[j]
+                  end
+                  -- Write some packet data
+                  for j = 0, c.writebytes do
+                     p.data[j] = i
+                  end
+
+		  local sent = nil
+		  repeat
+		     sent = mc_maybe_tx(output, p)
 		  until sent ~= nil
 		  counters[i] = counters[i] + 1
 	       end


### PR DESCRIPTION
A problem with the current `struct link` and multiple processes is that the `read` and `write` members of the struct are read and modified every single time a packet is queued or dequeued.

http://dl.acm.org/citation.cfm?doid=1345206.1345215 (FastForward for efficient pipeline parallelism: a cache-optimized concurrent lock-free queue ) talks about this, and proposes improvements.

The easy improvement is to make the producer and consumer able to operate more independently by putting some control information into the data.  This is academic-speak for using a null pointer data value to indicate whether there is data available in the ring buffer.  This way, producers only have to look at `write` and consumers only have to look at `read`, and if we arrange for these members to be on separate cache lines, we can avoid the cache coherence transactions that result from modifying both values on every use of the link. That's what I try to implement here.

I haven't yet tried to implement the temporal slipping described in the paper.  Again, this appears to be academic-speak for priming the pipeline so that producers and consumers aren't accessing the same part of the packet data.  In other words, we want to make it so that the producer and consumer are accessing different cache lines.

Another paper (http://www.cse.cuhk.edu.hk/~pclee/www/pubs/ipdps10.pdf, A Lock-Free, Cache-Efficient Multi-Core Synchronization Mechanism for Line-Rate Network Traffic Monitoring) describes MCRingBuffer.  The main idea here is to improve cache locality by the use of local copies of the read and write pointers, and to accumulate a batch of several insertions/removals before updating the shared copy.