### PR TITLE
increase timeout for link_up to 1 second (from 250ms)

### DIFF
--- a/src/apps/intel/intel10g.lua
+++ b/src/apps/intel/intel10g.lua
@@ -550,14 +550,14 @@ end
 function M_sf:wait_linkup ()
    self.waitlu_ms = 0
    local mask = bits{Link_up=30}
-   for count = 1, 250 do
+   for count = 1, 1000 do
       if band(self.r.LINKS(), mask) == mask then
          self.waitlu_ms = count
          return self
       end
       C.usleep(1000)
    end
-   self.waitlu_ms = 250
+   self.waitlu_ms = 1000
    return self
 end
 


### PR DESCRIPTION
Not sure if this is the correct way to fix an annoying link-up detection problem we experience with a SFP+ 82599ES card and patch cables to an Ethernet Switch. Without this patch, snabb terminates with 'never got link up:' and eventually succeeds after restarting Snabb a few times (typically 3 to 5 times). 
This patch extends the waiting time for a successful link up after triggering auto-negotiation. 
Needs probably some tuning and the "right" delay is above 500ms, at least in our lab, hence setting it to 1sec. This doesn't add any delay for systems with fast auto-negotiation.  
Comments / tests welcome.