### PR TITLE
Update scripts/snabb_doc.sh for #829

### DIFF
--- a/src/scripts/snabb_doc.sh
+++ b/src/scripts/snabb_doc.sh
@@ -74,7 +74,9 @@ function index_out { echo $docdir/index.html;   }
 
 function build_doc1 {
     (cd $(repo_path)/src && git checkout $1 && make doc/snabbswitch.html) \
-        && mv $(repo_path)/src/doc/snabbswitch.html $2
+        && mv $(repo_path)/src/doc/snabbswitch.html $2 \
+ || (cd $(repo_path)/src && git checkout $1 && make obj/doc/snabbswitch.html) \
+        && mv $(repo_path)/src/obj/doc/snabbswitch.html $2
 }
 
 function build_doc {

--- a/src/scripts/snabb_doc.sh
+++ b/src/scripts/snabb_doc.sh
@@ -73,10 +73,10 @@ function tag_out   { echo $docdir/tag/$1.html;  }
 function index_out { echo $docdir/index.html;   }
 
 function build_doc1 {
-    (cd $(repo_path)/src && git checkout $1 && make doc/snabbswitch.html) \
-        && mv $(repo_path)/src/doc/snabbswitch.html $2 \
- || (cd $(repo_path)/src && git checkout $1 && make obj/doc/snabbswitch.html) \
-        && mv $(repo_path)/src/obj/doc/snabbswitch.html $2
+    ((cd $(repo_path)/src && git checkout $1 && make doc/snabbswitch.html) \
+        && mv $(repo_path)/src/doc/snabbswitch.html $2) \
+ || ((cd $(repo_path)/src && git checkout $1 && make obj/doc/snabbswitch.html) \
+        && mv $(repo_path)/src/obj/doc/snabbswitch.html $2)
 }
 
 function build_doc {


### PR DESCRIPTION
This updates`scripts/snabb_doc.sh` to work with #829, while still supporting pre-#829 PRs.